### PR TITLE
Some changes to the infoview

### DIFF
--- a/ftplugin/lean/infoview.vim
+++ b/ftplugin/lean/infoview.vim
@@ -1,0 +1,2 @@
+" required for infoview
+setlocal updatetime=100

--- a/lua/lean/infoview.lua
+++ b/lua/lean/infoview.lua
@@ -5,7 +5,7 @@ local M = {_infoview = nil, _opts = {}}
 local _INFOVIEW_BUF_NAME = 'lean://infoview'
 local _DEFAULT_BUF_OPTIONS = {
   bufhidden = 'wipe',
-  filetype = 'lean',
+  filetype = 'leaninfo',
 }
 local _DEFAULT_WIN_OPTIONS = {
   cursorline = false,
@@ -73,11 +73,6 @@ function M.ensure_open()
 
   vim.cmd "vsplit"
   vim.cmd(string.format("buffer %d", bufnr))
-
-  -- We're cheating by calling this a Lean file, but tree-sitter won't
-  -- know how to deal with our cheating until we teach it, so turn it
-  -- off even for Lean 4.
-  pcall(vim.cmd, 'TSBufDisable highlight')
 
   local winnr = vim.api.nvim_get_current_win()
 

--- a/lua/lean/infoview.lua
+++ b/lua/lean/infoview.lua
@@ -71,7 +71,7 @@ function M.ensure_open()
 
   local current_window = vim.api.nvim_get_current_win()
 
-  vim.cmd "vsplit"
+  vim.cmd "botright vsplit"
   vim.cmd(string.format("buffer %d", bufnr))
 
   local winnr = vim.api.nvim_get_current_win()


### PR DESCRIPTION
I've been trying out the nvim extension, and these are some minor issues that I've run into.  Please tell me if I should rather put them in my init.vim instead.

* The LSP client used to run on the infoview because it has the lean filetype.  This is annoying because it shows error messages in the infoview, so I've changed it to a leaninfo filetype.
* The infoview opened on the left side for me, and more importantly, the infoview was the current window so I always had to switch back to the lean file.  (Maybe that's because I don't have `splitright` set.)
* It took me a while to figure out why the infoview had such a huge delay.  Apparently the infoview updates are tied to the updatetime setting, which defaults to 4000ms.  I've put in a reasonable default value to prevent surprises.  (Although that's probably not the best way since you can't override it.)
* The key feature of the infoview in vscode is that it show both the goals as well as the error messages on the current line.  This is important because most lean errors are multi-line messages, but the usual diagnostic displays focus on showing only single-line messages, making it hard to read the full error.  Furthermore, many error messages are morally goals anyhow (e.g. the "don't know how to synthesize placeholder" error shows the goal at the underscore).  Besides, there's enough screen real estate in the infoview.