### PR TITLE
treesitter: do not highlight anonymous constructors

### DIFF
--- a/queries/lean/highlights.scm
+++ b/queries/lean/highlights.scm
@@ -66,8 +66,6 @@
 (binders
   type: (identifier) @type)
 
-(anonymous_constructor) @constructor
-
 ["if" "then" "else"] @conditional
 
 ["for" "in" "do"] @repeat


### PR DESCRIPTION
Everything inside brackets `⟨let x := 42; x + x⟩` was highlighted differently, which is surprising and not how the vscode and emacs highlighting works.