### PR TITLE
Add builtin abbreviation expander and customize leader character

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,6 +93,11 @@ In e.g. your ``init.lua``:
     require('lean').setup{
         -- Abbreviation support
         abbreviations = {,
+            -- Set one of the following to true to enable abbreviations
+            compe = false, -- nvim-compe source
+            snippets = false, -- snippets.nvim source
+            enable = false, -- built-in expander
+            -- additional abbreviations:
             extra = {
                 -- Add a \wknight abbreviation to insert ♘
                 --
@@ -104,10 +109,6 @@ In e.g. your ``init.lua``:
             -- change if you don't like the backslash
             -- (comma is a popular choice on French keyboards)
             leader = '\\',
-            -- Set one of the following to true to enable abbreviations
-            compe = false, -- nvim-compe source
-            snippets = false, -- snippets.nvim source
-            enable = false, -- built-in expander
         }
         -- Enable suggested mappings?
         --

--- a/README.rst
+++ b/README.rst
@@ -90,9 +90,7 @@ In e.g. your ``init.lua``:
 .. code-block:: lua
 
     require('lean').setup{
-        -- Enable abbreviation support?
-        --
-        -- false to disable, otherwise a table of options described below
+        -- Abbreviation support?
         abbreviations = {,
             extra = {
                 -- Add a \wknight abbreviation to insert ♘
@@ -102,6 +100,11 @@ In e.g. your ``init.lua``:
                 -- this if so desired.
                 wknight = '♘',
             },
+            -- change if you don't like the backslash
+            leader = '\\',
+            -- set true to enable
+            compe = false,
+            snippets = false,
         }
         -- Enable suggested mappings?
         --

--- a/README.rst
+++ b/README.rst
@@ -50,9 +50,10 @@ part of this plugin.
 Features
 --------
 
-* abbreviation (unicode character) insertion using either
+* abbreviation (unicode character) insertion, can also provide a
   `nvim-compe <https://github.com/hrsh7th/nvim-compe>`_ or
   `snippets.nvim <https://github.com/norcalli/snippets.nvim>`_
+  source.
 
 * Initial implementations of some editing helpers (note: no
   mappings are associated with these by default unless you call
@@ -90,7 +91,7 @@ In e.g. your ``init.lua``:
 .. code-block:: lua
 
     require('lean').setup{
-        -- Abbreviation support?
+        -- Abbreviation support
         abbreviations = {,
             extra = {
                 -- Add a \wknight abbreviation to insert ♘
@@ -101,10 +102,12 @@ In e.g. your ``init.lua``:
                 wknight = '♘',
             },
             -- change if you don't like the backslash
+            -- (comma is a popular choice on French keyboards)
             leader = '\\',
-            -- set true to enable
-            compe = false,
-            snippets = false,
+            -- Set one of the following to true to enable abbreviations
+            compe = false, -- nvim-compe source
+            snippets = false, -- snippets.nvim source
+            enable = false, -- built-in expander
         }
         -- Enable suggested mappings?
         --

--- a/README.rst
+++ b/README.rst
@@ -94,9 +94,9 @@ In e.g. your ``init.lua``:
         -- Abbreviation support
         abbreviations = {,
             -- Set one of the following to true to enable abbreviations
+            builtin = false, -- built-in expander
             compe = false, -- nvim-compe source
             snippets = false, -- snippets.nvim source
-            enable = false, -- built-in expander
             -- additional abbreviations:
             extra = {
                 -- Add a \wknight abbreviation to insert ♘

--- a/lua/lean/abbreviations.lua
+++ b/lua/lean/abbreviations.lua
@@ -178,7 +178,7 @@ function M.enable(opts)
     compe_nvim_enable(require('compe'), add_leader(M.leader, M.abbreviations))
   end
 
-  if opts.enable then
+  if opts.builtin then
     enable_builtin()
   end
 end

--- a/lua/lean/abbreviations.lua
+++ b/lua/lean/abbreviations.lua
@@ -91,10 +91,20 @@ function M._insert_char_pre()
       end_right_gravity = true,
     })
     -- override only for the duration of the abbreviation (clashes with autocompletion plugins)
-    vim.api.nvim_buf_set_keymap(0, 'i', '<CR>', "<C-O>:lua require'lean.abbreviations'.convert()<CR><CR>", {noremap = true})
-    vim.api.nvim_buf_set_keymap(0, 'i', '<Tab>', "<C-O>:lua require'lean.abbreviations'.convert()<CR>", {noremap = true})
+    vim.api.nvim_buf_set_keymap(0, 'i', '<CR>', 'v:lua._lean_abbreviations_enter_expr()', {expr = true, noremap = true})
+    vim.api.nvim_buf_set_keymap(0, 'i', '<Tab>', 'v:lua._lean_abbreviations_tab_expr()', {expr = true, noremap = true})
     return
   end
+end
+
+function _G._lean_abbreviations_enter_expr()
+  M.convert(true)
+  return '\n'
+end
+
+function _G._lean_abbreviations_tab_expr()
+  M.convert(true)
+  return ' '
 end
 
 function M.convert_abbrev(abbrev)

--- a/lua/lean/abbreviations.lua
+++ b/lua/lean/abbreviations.lua
@@ -7,11 +7,15 @@ function M.load()
   local this_file = debug.getinfo(2, "S").source:sub(2)
   local base_directory = vim.fn.fnamemodify(this_file, ":h:h:h")
   local path = base_directory .. '/vscode-lean/abbreviations.json'
-  local lean_abbreviations = {}
-  for from, to in pairs(vim.fn.json_decode(vim.fn.readfile(path))) do
-    lean_abbreviations["\\" .. from] = to
+  return vim.fn.json_decode(vim.fn.readfile(path))
+end
+
+local function add_leader(leader, abbrevs)
+  local with_leader = {}
+  for from, to in pairs(abbrevs) do
+    with_leader[leader .. from] = to
   end
-  return lean_abbreviations
+  return with_leader
 end
 
 local function compe_nvim_enable(compe, lean_abbreviations)
@@ -34,17 +38,20 @@ local function snippets_nvim_enable(snippets, lean_abbreviations)
 end
 
 function M.enable(opts)
-  local lean_abbreviations = M.load()
+  local leader = opts.leader or '\\'
 
+  local lean_abbreviations = M.load()
   for from, to in pairs(opts.extra or {}) do
-    lean_abbreviations["\\" .. from] = to
+    lean_abbreviations[from] = to
   end
 
-  local has_snippets, snippets = pcall(require, 'snippets')
-  if has_snippets then snippets_nvim_enable(snippets, lean_abbreviations) end
+  if opts.snippets then
+    snippets_nvim_enable(require('snippets'), add_leader(leader, lean_abbreviations))
+  end
 
-  local has_compe, compe = pcall(require, 'compe')
-  if has_compe then compe_nvim_enable(compe, lean_abbreviations) end
+  if opts.compe then
+    compe_nvim_enable(require('compe'), add_leader(leader, lean_abbreviations))
+  end
 end
 
 return M

--- a/lua/lean/abbreviations.lua
+++ b/lua/lean/abbreviations.lua
@@ -37,20 +37,139 @@ local function snippets_nvim_enable(snippets, lean_abbreviations)
   snippets.snippets = all_snippets
 end
 
-function M.enable(opts)
-  local leader = opts.leader or '\\'
+local abbr_mark_ns = vim.api.nvim_create_namespace('leanAbbreviationMark')
 
-  local lean_abbreviations = M.load()
+local function get_extmark_range(abbr_ns, id, buffer)
+  local row, col, details = unpack(
+    vim.api.nvim_buf_get_extmark_by_id(buffer or 0, abbr_ns, id, {details = true}))
+  return row, col, details and details.end_row, details and details.end_col
+end
+
+function M._clear_abbr_mark()
+  vim.api.nvim_buf_del_extmark(0, abbr_mark_ns, M.abbr_mark)
+  M.abbr_mark = nil
+  vim.api.nvim_buf_del_keymap(0, 'i', '<CR>')
+  vim.api.nvim_buf_del_keymap(0, 'i', '<Tab>')
+end
+
+function M._insert_char_pre()
+  local char = vim.api.nvim_get_vvar('char')
+
+  if M.abbr_mark then
+    if vim.tbl_contains({'{', '}', '(', ')', ' '}, char) then
+      return M.convert(true)
+    end
+  end
+
+  -- typing \\ should result in \ and exit abbreviation mode
+  if M.abbr_mark and char == M.leader then
+    local row1, col1, row2, col2 = get_extmark_range(abbr_mark_ns, M.abbr_mark)
+    if row1 and row1 == row2 then
+      local text = vim.api.nvim_buf_get_lines(0, row1, row1+1, true)[1]:sub(col1 + 1, col2)
+      if text == M.leader then
+        M._clear_abbr_mark()
+        local tmp_extmark = vim.api.nvim_buf_set_extmark(0, abbr_mark_ns, row1, col1,
+          { end_line = row2, end_col = col2 })
+        return vim.schedule(function()
+          row1, col1, row2, col2 = get_extmark_range(abbr_mark_ns, tmp_extmark)
+          if not row1 then return end
+          vim.api.nvim_buf_del_extmark(0, abbr_mark_ns, tmp_extmark)
+          vim.api.nvim_buf_set_text(0, row1, col1, row2, col2, {})
+        end)
+      end
+    end
+  end
+
+  if not M.abbr_mark and char == M.leader then
+    local row, col = unpack(vim.api.nvim_win_get_cursor(0))
+    row = row - 1
+    M.abbr_mark = vim.api.nvim_buf_set_extmark(0, abbr_mark_ns, row, col, {
+      hl_group = 'leanAbbreviationMark',
+      end_line = row,
+      end_col = col,
+      right_gravity = false,
+      end_right_gravity = true,
+    })
+    -- override only for the duration of the abbreviation (clashes with autocompletion plugins)
+    vim.api.nvim_buf_set_keymap(0, 'i', '<CR>', "<C-O>:lua require'lean.abbreviations'.convert()<CR><CR>", {noremap = true})
+    vim.api.nvim_buf_set_keymap(0, 'i', '<Tab>', "<C-O>:lua require'lean.abbreviations'.convert()<CR>", {noremap = true})
+    return
+  end
+end
+
+function M.convert_abbrev(abbrev)
+  if abbrev:find(M.leader) ~= 1 then return abbrev end
+  abbrev = abbrev:sub(#M.leader + 1)
+  if abbrev:find(M.leader) == 1 then
+    return M.leader .. M.convert_abbrev(abbrev:sub(#M.leader + 1))
+  end
+  local matchlen, fromlen, repl = 0, 99999, ""
+  for from, to in pairs(M.abbreviations) do
+    local curmatchlen = 0
+    for i = 1, math.min(#abbrev, #from) do
+      if abbrev:byte(i) == from:byte(i) then
+        curmatchlen = i
+      else
+        break
+      end
+    end
+    if curmatchlen > matchlen or (curmatchlen == matchlen and #from < fromlen) then
+      matchlen, fromlen, repl = curmatchlen, #from, to
+    end
+  end
+  if matchlen == 0 then return M.leader .. abbrev end
+  return repl .. M.convert_abbrev(abbrev:sub(matchlen + 1))
+end
+
+function M.convert(needs_schedule)
+  if not M.abbr_mark then return end
+  local row1, col1, row2, col2 = get_extmark_range(abbr_mark_ns, M.abbr_mark)
+  M._clear_abbr_mark()
+  if not row1 then return end
+
+  local tmp_extmark = vim.api.nvim_buf_set_extmark(0, abbr_mark_ns, row1, col1,
+    { end_line = row2, end_col = col2 })
+  local conv = function()
+    row1, col1, row2, col2 = get_extmark_range(abbr_mark_ns, tmp_extmark)
+    if not row1 or row1 ~= row2 then return end
+    vim.api.nvim_buf_del_extmark(0, abbr_mark_ns, tmp_extmark)
+    local text = vim.api.nvim_buf_get_lines(0, row1, row1+1, true)[1]:sub(col1 + 1, col2)
+    vim.api.nvim_buf_set_text(0, row1, col1, row2, col2, {M.convert_abbrev(text)})
+  end
+  if needs_schedule then vim.schedule(conv) else conv() end
+end
+
+function M.enable_builtin()
+  vim.api.nvim_exec([[
+    augroup LeanAbbreviations
+      autocmd!
+      autocmd InsertCharPre *.lean lua require'lean.abbreviations'._insert_char_pre()
+      autocmd InsertLeave *.lean lua require'lean.abbreviations'.convert()
+      autocmd BufLeave *.lean lua require'lean.abbreviations'.convert()
+    augroup END
+    hi def leanAbbreviationMark cterm=underline
+  ]], false)
+  -- CursorMoved CursorMovedI as well?
+end
+
+function M.enable(opts)
+  M.leader = opts.leader or '\\'
+
+  M.abbreviations = M.load()
   for from, to in pairs(opts.extra or {}) do
-    lean_abbreviations[from] = to
+    M.abbreviations[from] = to
   end
 
   if opts.snippets then
-    snippets_nvim_enable(require('snippets'), add_leader(leader, lean_abbreviations))
+    snippets_nvim_enable(require('snippets'), add_leader(M.leader, M.abbreviations))
   end
 
   if opts.compe then
-    compe_nvim_enable(require('compe'), add_leader(leader, lean_abbreviations))
+    compe_nvim_enable(require('compe'), add_leader(M.leader, M.abbreviations))
+  end
+
+  if opts.enable then
+    M.enable_builtin()
   end
 end
 

--- a/lua/lean/abbreviations.lua
+++ b/lua/lean/abbreviations.lua
@@ -157,7 +157,7 @@ function M.enable_builtin()
       autocmd InsertLeave *.lean lua require'lean.abbreviations'.convert()
       autocmd BufLeave *.lean lua require'lean.abbreviations'.convert()
     augroup END
-    hi def leanAbbreviationMark cterm=underline
+    hi def leanAbbreviationMark cterm=underline gui=underline guisp=Gray
   ]], false)
   -- CursorMoved CursorMovedI as well?
 end

--- a/lua/tests/abbreviations_spec.lua
+++ b/lua/tests/abbreviations_spec.lua
@@ -34,7 +34,7 @@ describe('abbreviations', function()
 
   describe('programmatic API', function()
     it('provides access to loaded abbreviations', function()
-      assert.is.equal('α', require('lean.abbreviations').load()['\\a'])
+      assert.is.equal('α', require('lean.abbreviations').load()['a'])
     end)
   end)
 end)

--- a/scripts/minimal_init.lua
+++ b/scripts/minimal_init.lua
@@ -13,4 +13,8 @@ vim.api.nvim_exec([[
   runtime! plugin/plenary.vim
 ]], false)
 
-require('lean').setup{}
+require('lean').setup{
+  abbreviations = {
+    snippets = true,
+  },
+}


### PR DESCRIPTION
I didn't find the the snippets and completion plugins ergonomic enough to enter unicode characters.  It's something you do all the time, so it shouldn't require extra hotkeys.

This PR adds a simple extmarks-based expander for abbreviations (e.g. typing `\a\_0)` expands into `α₀)`).  I also made the leader character configurable (which was a widely requested feature in vscode).

There are some rough edges left (e.g. exiting insert mode while in an abbreviation will make the cursor jump), but overall I think it's good enough for everyday use and it works for me.