### PR TITLE
Limit testing scope of infoview interactions to `infoview_spec.lua`.

### DIFF
--- a/lua/tests/helpers.lua
+++ b/lua/tests/helpers.lua
@@ -1,6 +1,5 @@
 local assert = require('luassert')
 
-local infoview = require('lean.infoview')
 local lean = require('lean')
 
 local api = vim.api
@@ -11,14 +10,13 @@ local timeout = vim.env.LEAN_NVIM_TEST_TIMEOUT or 1000
 -- everything disabled by default to encourage unit testing
 local default_config = {
   abbreviations = {
-      builtin = false,
-      compe = false,
-      snippets = false,
+    builtin = false,
+    compe = false,
+    snippets = false,
   },
   mappings = false,
   infoview = {
-      -- will likely make this false later
-      enable = true
+    enable = false
   },
   lsp = {
     enable = false
@@ -71,17 +69,10 @@ function helpers.clean_buffer(contents, callback)
       end
 
       api.nvim_buf_set_lines(bufnr, 0, -1, false, vim.split(contents, '\n'))
-
-      local infoview_info = infoview.open()
       callback{
         source_file = { bufnr = bufnr },
-        infoview = {
-          bufnr = infoview_info.bufnr,
-          window = infoview_info.window,
-        },
       }
     end)
-    infoview.close()
     vim.api.nvim_buf_delete(bufnr, { force = true })
   end
 end

--- a/lua/tests/infoview_spec.lua
+++ b/lua/tests/infoview_spec.lua
@@ -1,10 +1,14 @@
+local infoview = require('lean.infoview')
 local clean_buffer = require('tests.helpers').clean_buffer
 
 describe('infoview', function()
   require('tests.helpers').setup { infoview = { enable = true } }
+
+  local infoview_info = infoview.open()
   it('starts with the window position at the top', clean_buffer('',
-    function(context)
-      local cursor = vim.api.nvim_win_get_cursor(context.infoview.window)
+    function(_)
+      local cursor = vim.api.nvim_win_get_cursor(infoview_info.window)
       assert.is.same(1, cursor[1])
     end))
+  infoview.close()
 end)


### PR DESCRIPTION
Follows up on separation of testing functionality from #46.