### PR TITLE
Use 'minfixwidth to handle width setting, rather than manual futzing.

### DIFF
--- a/lua/lean/infoview.lua
+++ b/lua/lean/infoview.lua
@@ -15,6 +15,7 @@ local _DEFAULT_WIN_OPTIONS = {
   number = false,
   relativenumber = false,
   spell = false,
+  winfixwidth = true,
   wrap = true,
 }
 
@@ -29,15 +30,6 @@ local _SEVERITY = {
 -- Get the ID of the infoview corresponding to the current window.
 local function get_idx()
   return 0
-end
-
-function M._maybe_resize_infoviews()
-  local max_width = M._opts.max_width or 79
-  for _, infoview in pairs(M._infoviews) do
-    if vim.api.nvim_win_get_width(infoview.window) > max_width then
-      vim.api.nvim_win_set_width(infoview.window, max_width)
-    end
-  end
 end
 
 function M.update(infoview_bufnr)
@@ -101,9 +93,9 @@ function M.update(infoview_bufnr)
 end
 
 function M.enable(opts)
+  opts.width = opts.width or 50
   M._opts = opts
   set_augroup("LeanInfoview", [[
-    autocmd WinEnter * lua require'lean.infoview'._maybe_resize_infoviews()
     autocmd BufWinEnter *.lean lua require'lean.infoview'.ensure_open()
   ]])
 end
@@ -123,7 +115,7 @@ function M.ensure_open()
 
   local current_window = vim.api.nvim_get_current_win()
 
-  vim.cmd "botright vsplit"
+  vim.cmd("botright " .. M._opts.width .. "vsplit")
   vim.cmd(string.format("buffer %d", infoview_bufnr))
 
   local window = vim.api.nvim_get_current_win()
@@ -143,8 +135,6 @@ function M.ensure_open()
   ]], infoview_bufnr, infoview_bufnr))
 
   M._infoviews[infoview_idx] = { bufnr = infoview_bufnr, window = window }
-
-  M._maybe_resize_infoviews()
 
   return M._infoviews[infoview_idx]
 end


### PR DESCRIPTION
`max_width` has been replaced with a set `width` setting.

Also bumping down the "recommended" size from 79 to 50, which is closer to what I've been using, but comments welcome if any of you two prefer the larger size.

For prior art, see how nvim-dap-ui does this:

https://github.com/rcarriga/nvim-dap-ui/blob/af1361c6ffac5285ca88e14d06dd5b949eabd682/lua/dapui/windows.lua#L55-L59

Besides removing code, this fixes the infoview getting unreadably small
in very small windows, and also not applying max_width correctly on
VimResized (though the latter would have been fixable), i.e. when the
whole vim gets resized.

(winfixheight presumably will be necessary/nice if/when we have horizontal infoviews.)