### PR TITLE
Implement lean.abbreviations.reverse_lookup, and bind it to a key.

### DIFF
--- a/lua/lean/init.lua
+++ b/lua/lean/init.lua
@@ -8,6 +8,7 @@ local lean = {
       ["<LocalLeader>s"] = "<Cmd>lua require('lean.sorry').fill()<CR>";
       ["<LocalLeader>t"] = "<Cmd>lua require('lean.trythis').swap()<CR>";
       ["<LocalLeader>3"] = "<Cmd>lua require('lean.lean3').init()<CR>";
+      ["<LocalLeader>\\"] = "<Cmd>lua require('lean.abbreviations').show_reverse_lookup()<CR>";
     };
     i = {
     };

--- a/lua/tests/abbreviations_spec.lua
+++ b/lua/tests/abbreviations_spec.lua
@@ -37,5 +37,29 @@ describe('abbreviations', function()
     it('provides access to loaded abbreviations', function()
       assert.is.equal('α', require('lean.abbreviations').load()['a'])
     end)
+
+    it('provides reverse-lookup of loaded abbreviations', function()
+      assert.is.same(
+        { [2] = {'\\a', '\\Ga', '\\alpha'}},
+        require('lean.abbreviations').reverse_lookup('α')
+      )
+    end)
+
+    it('allows random trailing junk', function()
+      assert.is.same(
+        {
+          [3] = { '\\^-' },
+          [5] = { '\\-', '\\-1', '\\sy', '\\^-1', '\\inv' },
+        },
+        require('lean.abbreviations').reverse_lookup('⁻¹something something')
+      )
+    end)
+
+    it('returns an empty table for non-existing abbreviations', function()
+      assert.is.same(
+        {},
+        require('lean.abbreviations').reverse_lookup(' ')
+      )
+    end)
   end)
 end)


### PR DESCRIPTION
Returns (or previews) what abbreviation produces the symbol(s)
under the cursor.

Closes: #24

Demo:

[![asciicast](https://asciinema.org/a/s2IMGBNQPsl0eEOuurWa2ucuT.svg)](https://asciinema.org/a/s2IMGBNQPsl0eEOuurWa2ucuT)