### PR TITLE
Automatically generate vim documentation

### DIFF
--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -1,0 +1,59 @@
+name: Generate documentation
+
+on:
+  push:
+    branches-ignore:
+      - master
+
+jobs:
+  build-sources:
+    name: Generate docs
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - run: date +%F > todays-date
+      - name: Restore cache for today's nightly.
+        uses: actions/cache@v2
+        with:
+          path: build
+          key: ${{ runner.os }}-appimage-${{ hashFiles('todays-date') }}
+
+      - name: Prepare
+        run: |
+          test -d build || {
+            mkdir -p build
+            wget https://github.com/neovim/neovim/releases/download/nightly/nvim.appimage
+            chmod +x nvim.appimage
+            mv nvim.appimage ./build/nvim
+          }
+          mkdir -p ~/.local/share/nvim/site/pack/vendor/start
+          git clone --depth 1 https://github.com/neovim/nvim-lspconfig ~/.local/share/nvim/site/pack/vendor/start/nvim-lspconfig
+          git clone --depth 1 https://github.com/nvim-lua/plenary.nvim ~/.local/share/nvim/site/pack/vendor/start/plenary.nvim
+          git clone --depth 1 https://github.com/tjdevries/tree-sitter-lua ~/.local/share/nvim/site/pack/vendor/start/tree-sitter-lua
+          ln -s $(pwd) ~/.local/share/nvim/site/pack/vendor/start
+      - name: Build parser
+        run: |
+          # We have to build the parser every single time to keep up with parser changes
+          cd ~/.local/share/nvim/site/pack/vendor/start/tree-sitter-lua
+          mkdir -p build parser
+          cc -o ./build/parser.so -I./src src/parser.c src/scanner.cc -shared -Os -lstdc++ -fPIC
+          ln -s ../build/parser.so parser/lua.so
+          cd -
+      - name: Generating docs
+        run: |
+          export PATH="${PWD}/build/:${PATH}"
+          make docgen
+      # inspired by nvim-lspconfigs
+      - name: Update documentation
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMIT_MSG: |
+            [docgen] Update doc/lean.txt
+            skip-checks: true
+        run: |
+          git config user.email "actions@github"
+          git config user.name "Github Actions"
+          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+          git add doc/
+          # Only commit and push if we have changes
+          git diff --quiet && git diff --staged --quiet || (git commit -m "${COMMIT_MSG}"; git push origin HEAD:${GITHUB_REF})

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+doc/tags
 packpath/
 *.olean
 leanpkg.path

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
-.PHONY: test nvim lint
+.PHONY: docgen nvim lint test
+
 nvim:
 	nvim --noplugin -u scripts/minimal_init.lua $(ARGS)
+
+docgen:
+	nvim --headless --noplugin -u scripts/minimal_init.lua -c "luafile ./scripts/gendocs.lua" -c "qa"
 
 test:
 	nvim --headless --noplugin -u scripts/minimal_init.lua -c "PlenaryBustedDirectory lua/tests/ { minimal_init = './scripts/minimal_init.lua' }"

--- a/doc/lean.txt
+++ b/doc/lean.txt
@@ -1,0 +1,53 @@
+================================================================================
+                                                                     *lean.nvim*
+
+lean.nvim is a plugin providing Neovim support for the Lean interactive theorem
+prover, developed by Leonardo de Moura at Microsoft Research.
+
+To find out more, see https://github.com/Julian/lean.nvim.
+
+lean.setup({opts})                                              *lean.setup()*
+    Setup function to be run in your init.lua (or init.vim).
+
+
+    Parameters: ~
+        {opts} (table)  Configuration options
+
+
+
+================================================================================
+                                                            *lean.abbreviations*
+
+Support for abbreviations (unicode character replacement).
+
+abbreviations.load()                                    *abbreviations.load()*
+    Load the Lean abbreviations as a Lua table.
+
+
+
+abbreviations.reverse_lookup()                *abbreviations.reverse_lookup()*
+    Retrieve the table of abbreviations that would produce the given symbol.
+
+
+
+abbreviations.show_reverse_lookup()      *abbreviations.show_reverse_lookup()*
+    Show a preview window with the reverse-lookup of the current character.
+
+
+
+
+================================================================================
+sorry.fill()                                                    *sorry.fill()*
+    Fill the current cursor position with `sorry`s to discharge all goals.
+
+
+
+
+================================================================================
+trythis.swap()                                                *trythis.swap()*
+    Swap the first suggestion from Lean with the word under the cursor.
+
+
+
+
+ vim:tw=78:ts=8:ft=help:norl:

--- a/lua/lean/abbreviations.lua
+++ b/lua/lean/abbreviations.lua
@@ -1,3 +1,9 @@
+---@brief [[
+--- Support for abbreviations (unicode character replacement).
+---@brief ]]
+
+---@tag lean.abbreviations
+
 local M = {}
 
 local _MEMOIZED = nil

--- a/lua/lean/abbreviations.lua
+++ b/lua/lean/abbreviations.lua
@@ -4,13 +4,13 @@
 
 ---@tag lean.abbreviations
 
-local M = {}
+local abbreviations = {}
 
 local _MEMOIZED = nil
 local _CURSOR_MARKER = '$CURSOR'
 
 --- Load the Lean abbreviations as a Lua table.
-function M.load()
+function abbreviations.load()
   if _MEMOIZED ~= nil then return _MEMOIZED end
   local this_file = debug.getinfo(2, "S").source:sub(2)
   local base_directory = vim.fn.fnamemodify(this_file, ":h:h:h")
@@ -26,12 +26,12 @@ end
 --  The result is a table keyed by the length of the prefix match, and
 --  whose value is sorted such that shorter abbreviation suggestions are
 --  first.
-function M.reverse_lookup(symbol_plus_unknown)
+function abbreviations.reverse_lookup(symbol_plus_unknown)
   local reverse = {}
-  for key, value in pairs(M.load()) do
+  for key, value in pairs(abbreviations.load()) do
     if vim.startswith(symbol_plus_unknown, value) then
       reverse[#value] = reverse[#value] or {}
-      table.insert(reverse[#value], M.leader .. key)
+      table.insert(reverse[#value], abbreviations.leader .. key)
     end
   end
   for _, value in pairs(reverse) do
@@ -41,10 +41,10 @@ function M.reverse_lookup(symbol_plus_unknown)
 end
 
 --- Show a preview window with the reverse-lookup of the current character.
-function M.show_reverse_lookup()
+function abbreviations.show_reverse_lookup()
   local col = vim.api.nvim_win_get_cursor(0)[2] + 1
   local char = vim.api.nvim_get_current_line():sub(col)
-  local results = M.reverse_lookup(char)
+  local results = abbreviations.reverse_lookup(char)
   local lines
   if vim.tbl_isempty(results) then
     lines = {
@@ -104,27 +104,27 @@ local function get_extmark_range(abbr_ns, id, buffer)
 end
 
 local function _clear_abbr_mark()
-  vim.api.nvim_buf_del_extmark(0, abbr_mark_ns, M.abbr_mark)
-  M.abbr_mark = nil
+  vim.api.nvim_buf_del_extmark(0, abbr_mark_ns, abbreviations.abbr_mark)
+  abbreviations.abbr_mark = nil
   vim.api.nvim_buf_del_keymap(0, 'i', '<CR>')
   vim.api.nvim_buf_del_keymap(0, 'i', '<Tab>')
 end
 
-function M._insert_char_pre()
+function abbreviations._insert_char_pre()
   local char = vim.api.nvim_get_vvar('char')
 
-  if M.abbr_mark then
+  if abbreviations.abbr_mark then
     if vim.tbl_contains({'{', '}', '(', ')', ' '}, char) then
-      return M.convert(true)
+      return abbreviations.convert(true)
     end
   end
 
   -- typing \\ should result in \ and exit abbreviation mode
-  if M.abbr_mark and char == M.leader then
-    local row1, col1, row2, col2 = get_extmark_range(abbr_mark_ns, M.abbr_mark)
+  if abbreviations.abbr_mark and char == abbreviations.leader then
+    local row1, col1, row2, col2 = get_extmark_range(abbr_mark_ns, abbreviations.abbr_mark)
     if row1 and row1 == row2 then
       local text = vim.api.nvim_buf_get_lines(0, row1, row1+1, true)[1]:sub(col1 + 1, col2)
-      if text == M.leader then
+      if text == abbreviations.leader then
         _clear_abbr_mark()
         local tmp_extmark = vim.api.nvim_buf_set_extmark(0, abbr_mark_ns, row1, col1,
           { end_line = row2, end_col = col2 })
@@ -138,10 +138,10 @@ function M._insert_char_pre()
     end
   end
 
-  if not M.abbr_mark and char == M.leader then
+  if not abbreviations.abbr_mark and char == abbreviations.leader then
     local row, col = unpack(vim.api.nvim_win_get_cursor(0))
     row = row - 1
-    M.abbr_mark = vim.api.nvim_buf_set_extmark(0, abbr_mark_ns, row, col, {
+    abbreviations.abbr_mark = vim.api.nvim_buf_set_extmark(0, abbr_mark_ns, row, col, {
       hl_group = 'leanAbbreviationMark',
       end_line = row,
       end_col = col,
@@ -156,23 +156,23 @@ function M._insert_char_pre()
 end
 
 function _G._lean_abbreviations_enter_expr()
-  M.convert(true)
+  abbreviations.convert(true)
   return '\n'
 end
 
 function _G._lean_abbreviations_tab_expr()
-  M.convert(true)
+  abbreviations.convert(true)
   return ' '
 end
 
 local function convert_abbrev(abbrev)
-  if abbrev:find(M.leader) ~= 1 then return abbrev end
-  abbrev = abbrev:sub(#M.leader + 1)
-  if abbrev:find(M.leader) == 1 then
-    return M.leader .. convert_abbrev(abbrev:sub(#M.leader + 1))
+  if abbrev:find(abbreviations.leader) ~= 1 then return abbrev end
+  abbrev = abbrev:sub(#abbreviations.leader + 1)
+  if abbrev:find(abbreviations.leader) == 1 then
+    return abbreviations.leader .. convert_abbrev(abbrev:sub(#abbreviations.leader + 1))
   end
   local matchlen, fromlen, repl = 0, 99999, ""
-  for from, to in pairs(M.abbreviations) do
+  for from, to in pairs(abbreviations.abbreviations) do
     local curmatchlen = 0
     for i = 1, math.min(#abbrev, #from) do
       if abbrev:byte(i) == from:byte(i) then
@@ -185,13 +185,13 @@ local function convert_abbrev(abbrev)
       matchlen, fromlen, repl = curmatchlen, #from, to
     end
   end
-  if matchlen == 0 then return M.leader .. abbrev end
+  if matchlen == 0 then return abbreviations.leader .. abbrev end
   return repl .. convert_abbrev(abbrev:sub(matchlen + 1))
 end
 
-function M.convert(needs_schedule)
-  if not M.abbr_mark then return end
-  local row1, col1, row2, col2 = get_extmark_range(abbr_mark_ns, M.abbr_mark)
+function abbreviations.convert(needs_schedule)
+  if not abbreviations.abbr_mark then return end
+  local row1, col1, row2, col2 = get_extmark_range(abbr_mark_ns, abbreviations.abbr_mark)
   _clear_abbr_mark()
   if not row1 then return end
 
@@ -220,20 +220,20 @@ local function enable_builtin()
   -- CursorMoved CursorMovedI as well?
 end
 
-function M.enable(opts)
-  M.leader = opts.leader or '\\'
+function abbreviations.enable(opts)
+  abbreviations.leader = opts.leader or '\\'
 
-  M.abbreviations = M.load()
+  abbreviations.abbreviations = abbreviations.load()
   for from, to in pairs(opts.extra or {}) do
-    M.abbreviations[from] = to
+    abbreviations.abbreviations[from] = to
   end
 
   if opts.snippets then
-    snippets_nvim_enable(require('snippets'), add_leader(M.leader, M.abbreviations))
+    snippets_nvim_enable(require('snippets'), add_leader(abbreviations.leader, abbreviations.abbreviations))
   end
 
   if opts.compe then
-    compe_nvim_enable(require('compe'), add_leader(M.leader, M.abbreviations))
+    compe_nvim_enable(require('compe'), add_leader(abbreviations.leader, abbreviations.abbreviations))
   end
 
   if opts.builtin then
@@ -241,4 +241,4 @@ function M.enable(opts)
   end
 end
 
-return M
+return abbreviations

--- a/lua/lean/ft.lua
+++ b/lua/lean/ft.lua
@@ -1,4 +1,4 @@
-local M = {}
+local ft = {}
 
 local lean3 = require("lean.lean3")
 
@@ -8,21 +8,20 @@ local find_project_root = require('lspconfig.util').root_pattern('leanpkg.toml')
 -- do nasty things and not add the dependency for now.
 local _MARKER = '.*lean_version.*\".*:3.*'
 
-function M.detect()
-  local ft = "lean"
+function ft.detect()
   local project_root = find_project_root(vim.api.nvim_buf_get_name(0))
   if project_root then
     local result = vim.fn.readfile(project_root .. '/leanpkg.toml')
     for _, line in ipairs(result) do
-      if line:match(_MARKER) then ft = "lean3" end
+      if line:match(_MARKER) then return ft.set("lean3") end
     end
   end
-  M.set(ft)
+  ft.set("lean")
 end
 
-function M.set(ft)
-  vim.api.nvim_command("setfiletype " .. ft)
+function ft.set(filetype)
+  vim.api.nvim_command("setfiletype " .. filetype)
   if vim.bo.ft == "lean3" then lean3.init() end
 end
 
-return M
+return ft

--- a/lua/lean/init.lua
+++ b/lua/lean/init.lua
@@ -1,3 +1,12 @@
+---@brief [[
+--- lean.nvim is a plugin providing Neovim support for the Lean interactive
+--- theorem prover, developed by Leonardo de Moura at Microsoft Research.
+---
+--- To find out more, see https://github.com/Julian/lean.nvim.
+---@brief ]]
+
+---@tag lean.nvim
+
 local lean = {
   lsp = require('lean.lsp'),
   abbreviations = require('lean.abbreviations'),
@@ -15,6 +24,8 @@ local lean = {
   }
 }
 
+--- Setup function to be run in your init.lua (or init.vim).
+---@param opts table: Configuration options
 function lean.setup(opts)
   opts = opts or {}
 

--- a/lua/lean/lean3.lua
+++ b/lua/lean/lean3.lua
@@ -1,11 +1,11 @@
-local M = {}
+local lean3 = {}
 
-function M.init()
+function lean3.init()
   pcall(vim.cmd, 'TSBufDisable highlight')  -- tree-sitter-lean is lean4-only
   vim.b.lean3 = true
 end
 
-function M.update_infoview(set_lines)
+function lean3.update_infoview(set_lines)
   local params = vim.lsp.util.make_position_params()
   return vim.lsp.buf_request(0, "textDocument/hover", params, function(_, _, result)
     if not (type(result) == "table" and result.contents) then
@@ -21,4 +21,4 @@ function M.update_infoview(set_lines)
   end)
 end
 
-return M
+return lean3

--- a/lua/lean/lsp.lua
+++ b/lua/lean/lsp.lua
@@ -1,25 +1,25 @@
-local M = { handlers = {} }
+local lsp = { handlers = {} }
 
-function M.enable(opts)
+function lsp.enable(opts)
   opts.commands = vim.tbl_extend("keep", opts.commands or {}, {
     LeanPlainGoal = {
-      M.plain_goal;
+      lsp.plain_goal;
       description = "Describe the current tactic state."
     };
     LeanPlainTermGoal = {
-      M.plain_term_goal;
+      lsp.plain_term_goal;
       description = "Describe the expected type of the current term."
     };
   })
   opts.handlers = vim.tbl_extend("keep", opts.handlers or {}, {
-    ["$/lean/plainGoal"] = M.handlers.plain_goal_handler;
-    ["$/lean/plainTermGoal"] = M.handlers.plain_term_goal_handler;
+    ["$/lean/plainGoal"] = lsp.handlers.plain_goal_handler;
+    ["$/lean/plainTermGoal"] = lsp.handlers.plain_term_goal_handler;
   })
   require('lspconfig').leanls.setup(opts)
 end
 
 -- Fetch goal state information from the server.
-function M.plain_goal(bufnr, handler)
+function lsp.plain_goal(bufnr, handler)
   -- Shift forward by 1, since in vim it's easier to reach word
   -- boundaries in normal mode.
   local params = vim.lsp.util.make_position_params()
@@ -28,12 +28,12 @@ function M.plain_goal(bufnr, handler)
 end
 
 -- Fetch term goal state information from the server.
-function M.plain_term_goal(bufnr, handler)
+function lsp.plain_term_goal(bufnr, handler)
   local params = vim.lsp.util.make_position_params()
   return vim.lsp.buf_request(bufnr, "$/lean/plainTermGoal", params, handler)
 end
 
-function M.handlers.plain_goal_handler (_, method, result, _, _, config)
+function lsp.handlers.plain_goal_handler (_, method, result, _, _, config)
   config = config or {}
   config.focus_id = method
   if not (result and result.rendered) then
@@ -47,7 +47,7 @@ function M.handlers.plain_goal_handler (_, method, result, _, _, config)
   return vim.lsp.util.open_floating_preview(markdown_lines, "markdown", config)
 end
 
-function M.handlers.plain_term_goal_handler (_, method, result, _, _, config)
+function lsp.handlers.plain_term_goal_handler (_, method, result, _, _, config)
   config = config or {}
   config.focus_id = method
   if not (result and result.goal) then
@@ -58,4 +58,4 @@ function M.handlers.plain_term_goal_handler (_, method, result, _, _, config)
   )
 end
 
-return M
+return lsp

--- a/lua/lean/treesitter.lua
+++ b/lua/lean/treesitter.lua
@@ -1,6 +1,6 @@
-local M = {}
+local treesitter = {}
 
-function M.enable(opts)
+function treesitter.enable(opts)
   local has_treesitter, parsers = pcall(require, 'nvim-treesitter.parsers')
   if not has_treesitter then return end
 
@@ -13,4 +13,4 @@ function M.enable(opts)
   parsers.get_parser_configs().lean = opts
 end
 
-return M
+return treesitter

--- a/scripts/gendocs.lua
+++ b/scripts/gendocs.lua
@@ -1,0 +1,34 @@
+require('lean').setup()
+
+local docgen = require('docgen')
+
+local docs = {}
+
+docs.test = function(input_dir, output_file)
+  local input_files = vim.fn.globpath(input_dir, "**/*.lua", false, true)
+
+  -- Always put init.lua first, then you can do other stuff.
+  table.sort(input_files, function(a, b)
+    if string.find(a, "init.lua") then
+      return true
+    elseif string.find(b, "init.lua") then
+      return false
+    else
+      return a < b
+    end
+  end)
+
+  local output_file_handle = io.open(output_file, "w")
+
+  for _, input_file in ipairs(input_files) do
+    docgen.write(input_file, output_file_handle)
+  end
+
+  output_file_handle:write(" vim:tw=78:ts=8:ft=help:norl:\n")
+  output_file_handle:close()
+  vim.cmd [[checktime]]
+end
+
+docs.test('./lua/lean/', 'doc/lean.txt')
+
+return docs


### PR DESCRIPTION
This PR is noisy because of a commit (870d2472e0c1d77c856407f4f218f6b0fc4c3773) that seems required to get proper tags generated for module names... which is unfortunate, but without it, the output has `M.load()` in it as the name of `abbreviations.load`, and I don't see how to get around that...

The real change is just 4114bdf951d494f7986b4807f11b81de65cb5b0e, which:

* Gives us CI that auto-regenerates the `doc/lean.txt` file
* Adds exactly 2 new docstrings just to try this out

If you want to see the output, run `:h lean` and you should now see some vim docs (or at least some empty space waiting for them...). Or obviously they're here: https://github.com/Julian/lean.nvim/blob/doc/doc/lean.txt which are generated from the Lua docstrings.

For info on how to write those magic Lua docstrings, see here: https://github.com/tjdevries/tree-sitter-lua/blob/6497ca7a3ff963e2fcb6bb3e39d7699280ae633e/HOWTO.md

Comments welcome of course. (And if this is annoying to review because of the commit noise, do let me know).