### PR TITLE
Build Lean 3 fixture for tests.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,10 @@ jobs:
           elan default "${{ matrix.lean-version }}"
         if: runner.os == 'macOS'
 
+      - name: Build Lean 3 fixture
+        run: |
+          cd lua/tests/fixtures/example-lean3-project/ && leanpkg configure && leanpkg build
+
       - name: Install the Lean LSP
         run: sudo npm install -g lean-language-server
         if: contains(matrix.lean-version, 'lean:3')


### PR DESCRIPTION
I figured since Lean 4 does this automatically it would be best to explicitly do this for Lean 3 as well, just to standardize things. 