### PR TITLE
Separate Lean 3 and Lean 4 tests when using `clean_buffer`.

### DIFF
--- a/lua/tests/abbreviations_spec.lua
+++ b/lua/tests/abbreviations_spec.lua
@@ -1,29 +1,30 @@
 local helpers = require('tests.helpers')
 
-describe('abbreviations', function()
-  helpers.setup { abbreviations = { snippets = true } }
+helpers.setup { abbreviations = { snippets = true } }
+for _, ft in pairs({"lean3", "lean"}) do
+describe(ft .. ' abbreviations', function()
   describe('expansion', function()
     describe('snippets.nvim', function()
-      it('expands abbreviations', helpers.clean_buffer('', function()
+      it('expands abbreviations', helpers.clean_buffer(ft, '', function()
         require('snippets').use_suggested_mappings(true)
         helpers.insert('\\a<C-k>')
         assert.is.equal('α', vim.api.nvim_get_current_line())
       end))
 
       -- Really this needs to place the cursor too, but for now we just strip
-      it('handles placing the $CURSOR', helpers.clean_buffer('', function()
+      it('handles placing the $CURSOR', helpers.clean_buffer(ft, '', function()
         require('snippets').use_suggested_mappings(true)
         helpers.insert('foo \\<><C-k>bar, baz')
         assert.is.equal('foo ⟨bar, baz⟩', vim.api.nvim_get_current_line())
       end))
 
-      it('does not autoexpand', helpers.clean_buffer('', function()
+      it('does not autoexpand', helpers.clean_buffer(ft, '', function()
         require('snippets').use_suggested_mappings(true)
         helpers.insert('\\a')
         assert.is.equal('\\a', vim.api.nvim_get_current_line())
       end))
 
-      it('expands mid-word', helpers.clean_buffer('', function()
+      it('expands mid-word', helpers.clean_buffer(ft, '', function()
         pending('norcalli/snippets.nvim#17', function()
           require('snippets').use_suggested_mappings(true)
           helpers.insert('(\\a<C-k>')
@@ -63,3 +64,4 @@ describe('abbreviations', function()
     end)
   end)
 end)
+end

--- a/lua/tests/ft_spec.lua
+++ b/lua/tests/ft_spec.lua
@@ -1,6 +1,5 @@
+require('tests.helpers').setup {}
 describe('filetype detection', function()
-  require('tests.helpers').setup {}
-
   it('recognizes a lean 3 file',
     function(_)
       vim.api.nvim_command("edit lua/tests/fixtures/example-lean3-project/test.lean")

--- a/lua/tests/helpers.lua
+++ b/lua/tests/helpers.lua
@@ -63,13 +63,6 @@ local function set_unique_name_so_we_always_have_a_separate_fake_file(bufnr)
   api.nvim_buf_set_name(bufnr, unique_name)
 end
 
-function helpers.clean_buffer(contents, callback)
-  return function ()
-    helpers.clean_buffer_ft("lean3", contents, callback)()
-    helpers.clean_buffer_ft("lean", contents, callback)()
-  end
-end
-
 function helpers.wait_for_ready_lsp()
   local succeeded, _ = vim.wait(20000, vim.lsp.buf.server_ready)
   assert.message("LSP server was never ready.").True(succeeded)
@@ -80,7 +73,7 @@ end
 --  Waits for the LSP to be ready before proceeding with a given callback.
 --
 --  Yes c(lean) may be a double entendre, and no I don't feel bad.
-function helpers.clean_buffer_ft(ft, contents, callback)
+function helpers.clean_buffer(ft, contents, callback)
   return function()
     local bufnr = vim.api.nvim_create_buf(false, true)
     set_unique_name_so_we_always_have_a_separate_fake_file(bufnr)

--- a/lua/tests/infoview_lsp_spec.lua
+++ b/lua/tests/infoview_lsp_spec.lua
@@ -19,13 +19,12 @@ local function infoview_lsp_update(pos)
     return infoview.get_info_lines()
 end
 
+helpers.setup {
+  infoview = { enable = true },
+  lsp = { enable = true },
+  lsp3 = { enable = true },
+}
 describe('infoview', function()
-  helpers.setup {
-    infoview = { enable = true },
-    lsp = { enable = true },
-    lsp3 = { enable = true },
-  }
-
   it('lean 3', function()
     before_each(function()
       vim.api.nvim_command("edit lua/tests/fixtures/example-lean3-project/test.lean")

--- a/lua/tests/infoview_spec.lua
+++ b/lua/tests/infoview_spec.lua
@@ -1,13 +1,12 @@
 local infoview = require('lean.infoview')
 local get_num_wins = function() return #vim.api.nvim_list_wins() end
 
+require('tests.helpers').setup {
+  infoview = { enable = true },
+  lsp = { enable = true },
+  lsp3 = { enable = true },
+}
 describe('infoview', function()
-  require('tests.helpers').setup {
-    infoview = { enable = true },
-    lsp = { enable = true },
-    lsp3 = { enable = true },
-  }
-
   vim.api.nvim_command("edit lua/tests/fixtures/example-lean3-project/test.lean")
 
   local infoview_info = infoview.open()

--- a/lua/tests/infoview_start_spec.lua
+++ b/lua/tests/infoview_start_spec.lua
@@ -1,12 +1,11 @@
 local infoview = require('lean.infoview')
-local clean_buffer_ft = require('tests.helpers').clean_buffer_ft
+local clean_buffer = require('tests.helpers').clean_buffer
 
+require('tests.helpers').setup { infoview = { enable = true } }
 describe('infoview', function()
-  require('tests.helpers').setup { infoview = { enable = true } }
-
   local src_win = vim.api.nvim_get_current_win()
 
-  it('automatically opens', clean_buffer_ft('lean', '',
+  it('automatically opens', clean_buffer('lean', '',
     function(_)
       assert.is_true(infoview.is_open())
     end))

--- a/lua/tests/mappings_spec.lua
+++ b/lua/tests/mappings_spec.lua
@@ -1,9 +1,10 @@
 local lean = require('lean')
 local clean_buffer = require('tests.helpers').clean_buffer
 
-describe('mappings', function()
-  require('tests.helpers').setup {}
-  it('binds mappings in the current buffer and not others', clean_buffer('',
+require('tests.helpers').setup {}
+for _, ft in pairs({"lean3", "lean"}) do
+describe(ft .. 'mappings', function()
+  it('binds mappings in the current buffer and not others', clean_buffer(ft, '',
   function()
     lean.use_suggested_mappings(true)
     assert.is.same(
@@ -16,3 +17,4 @@ describe('mappings', function()
     vim.cmd('bwipeout')
   end))
 end)
+end

--- a/lua/tests/sorry_spec.lua
+++ b/lua/tests/sorry_spec.lua
@@ -1,11 +1,9 @@
 local helpers = require('tests.helpers')
-local clean_buffer_ft = helpers.clean_buffer_ft
+local clean_buffer = helpers.clean_buffer
 
+helpers.setup { lsp3 = { enable = true } }
 describe('sorry', function()
-
-  helpers.setup { lsp3 = { enable = true } }
-
-  it('inserts sorries for each remaining goal', clean_buffer_ft("lean3", [[
+  it('inserts sorries for each remaining goal', clean_buffer("lean3", [[
 def foo (n : nat) : n = n := begin
   induction n with d hd,
 end]], function()
@@ -24,7 +22,7 @@ end]], table.concat(vim.fn.getline(1, '$'), '\n'))
   end))
 
   it('indents sorry blocks when needed',
-    clean_buffer_ft("lean3", [[
+    clean_buffer("lean3", [[
 def foo (n : nat) : n = n := begin
   induction n with d hd,
 
@@ -44,7 +42,7 @@ def foo (n : nat) : n = n := begin
 end]], table.concat(vim.fn.getline(1, '$'), '\n'))
   end))
 
-  it('does nothing if there are no goals', clean_buffer_ft("lean3", [[
+  it('does nothing if there are no goals', clean_buffer("lean3", [[
 def foo (n : nat) : n = n := begin
   refl,
 end]], function()

--- a/lua/tests/trythis_spec.lua
+++ b/lua/tests/trythis_spec.lua
@@ -1,8 +1,8 @@
 local helpers = require('tests.helpers')
 
+helpers.setup { lsp3 = { enable = true } }
 describe('trythis', function()
-  helpers.setup { lsp3 = { enable = true } }
-  it('replaces a single try this', helpers.clean_buffer_ft("lean3", [[
+  it('replaces a single try this', helpers.clean_buffer("lean3", [[
 meta def whatshouldIdo := (do tactic.trace "Try this: existsi 2; refl\n")
 example : ∃ n, n = 2 := by whatshouldIdo]], function()
     vim.api.nvim_command('normal G$')
@@ -16,7 +16,7 @@ example : ∃ n, n = 2 := by whatshouldIdo]], function()
   end))
 
   -- Emitted by e.g. pretty_cases
-  it('replaces multiline try this messages', helpers.clean_buffer_ft("lean3", [[
+  it('replaces multiline try this messages', helpers.clean_buffer("lean3", [[
 meta def whatshouldIdo := (do tactic.trace "Try this: existsi 2,\nrefl,\n")
 example : ∃ n, n = 2 := by {
   whatshouldIdo
@@ -35,7 +35,7 @@ example : ∃ n, n = 2 := by {
 
   -- Emitted by e.g. hint
   -- luacheck: ignore
-  it('replaces squashed together try this messages', helpers.clean_buffer_ft("lean3", [[
+  it('replaces squashed together try this messages', helpers.clean_buffer("lean3", [[
 meta def whatshouldIdo := (do tactic.trace "the following tactics solve the goal\n---\nTry this: finish\nTry this: tauto\n")
 example : ∃ n, n = 2 := by whatshouldIdo]], function()
     vim.api.nvim_command('normal G$')


### PR DESCRIPTION
Simplest way I could think to do this while maintaining the test structure of each `*_spec.lua` file.