### PR TITLE
Add infoview CursorHold(I) unit tests.

### DIFF
--- a/lua/tests/infoview/run_spec.lua
+++ b/lua/tests/infoview/run_spec.lua
@@ -11,6 +11,22 @@ describe('infoview', function()
 
   local infoview_info = infoview.open()
 
+  local function update_enabled(state, _)
+    local cursor_hold = string.find(vim.api.nvim_exec("autocmd CursorHold", true), "LeanInfoviewUpdate")
+    local cursor_hold_i = string.find(vim.api.nvim_exec("autocmd CursorHoldI", true), "LeanInfoviewUpdate")
+    if state.mod then
+      return cursor_hold and cursor_hold_i
+    end
+      return cursor_hold or cursor_hold_i
+  end
+
+  assert:register("assertion", "update_enabled", update_enabled)
+
+  it('CursorHold(I) enabled when opened',
+  function(_)
+    assert.update_enabled()
+  end)
+
   it('closes',
   function(_)
     assert.is_true(vim.api.nvim_win_is_valid(infoview_info.window))
@@ -28,6 +44,11 @@ describe('infoview', function()
     assert.is.equal(num_wins, get_num_wins())
   end)
 
+  it('CursorHold(I) disabled when closed',
+  function(_)
+    assert.is_not.update_enabled()
+  end)
+
   it('opens',
   function(_)
     local num_wins = get_num_wins()
@@ -43,5 +64,10 @@ describe('infoview', function()
     vim.api.nvim_command("edit lua/tests/fixtures/example-lean3-project/test/test1.lean")
     assert.is_true(vim.api.nvim_win_is_valid(infoview_info.window))
     assert.is.equal(num_wins, get_num_wins())
+  end)
+
+  it('CursorHold(I) enabled when re-opened',
+  function(_)
+    assert.update_enabled()
   end)
 end)


### PR DESCRIPTION
Still haven't looked into how to trigger `CursorHold`/`CursorHoldI` from within our tests - however, I actually prefer doing it this way because we're only testing exactly what we need (the presence of the autocommands).