### PR TITLE
Backport diagnostic reporting to Lean 3.

### DIFF
--- a/doc/lean.txt
+++ b/doc/lean.txt
@@ -42,6 +42,11 @@ infoview.get_info_lines()                          *infoview.get_info_lines()*
 
 
 
+infoview.is_empty()                                      *infoview.is_empty()*
+    Is the infoview not showing anything?
+
+
+
 
 ================================================================================
                                                       *lean.infoview.components*

--- a/doc/lean.txt
+++ b/doc/lean.txt
@@ -44,6 +44,34 @@ infoview.get_info_lines()                          *infoview.get_info_lines()*
 
 
 ================================================================================
+                                                      *lean.infoview.components*
+
+Infoview components which can be assembled to show various information about
+the current Lean module or state.
+
+components.goal({goal})                                    *components.goal()*
+    The current (tactic) goal state.
+
+
+    Parameters: ~
+        {goal} (table)  a Lean4 `plainGoal` LSP response
+
+
+components.term_goal({term_goal})                     *components.term_goal()*
+    The current (term) goal state.
+
+
+    Parameters: ~
+        {term_goal} (table)  a Lean4 `plainTermGoal` LSP response
+
+
+components.diagnostics()                            *components.diagnostics()*
+    Diagnostic information for the current line from the Lean server.
+
+
+
+
+================================================================================
 sorry.fill()                                                    *sorry.fill()*
     Fill the current cursor position with `sorry`s to discharge all goals.
 

--- a/lua/lean/infoview.lua
+++ b/lua/lean/infoview.lua
@@ -167,7 +167,7 @@ end
 
 --- Is the infoview not showing anything?
 function infoview.is_empty()
-  return vim.deep_equal(infoview.get_info_lines(), _NOTHING_TO_SHOW)
+  return vim.deep_equal(infoview.get_info_lines(), table.concat(_NOTHING_TO_SHOW, "\n"))
 end
 
 return infoview

--- a/lua/lean/infoview.lua
+++ b/lua/lean/infoview.lua
@@ -1,3 +1,4 @@
+local components = require('lean.infoview.components')
 local lean3 = require('lean.lean3')
 local leanlsp = require('lean.lsp')
 local set_augroup = require('lean._nvimapi').set_augroup
@@ -19,14 +20,6 @@ local _DEFAULT_WIN_OPTIONS = {
   wrap = true,
 }
 
-local _SEVERITY = {
-  [0] = "other",
-  [1] = "error",
-  [2] = "warning",
-  [3] = "information",
-  [4] = "hint",
-}
-
 -- Get the ID of the infoview corresponding to the current window.
 local function get_idx()
   return vim.api.nvim_win_get_tabpage(0)
@@ -35,41 +28,13 @@ end
 function infoview.update()
   local infoview_bufnr = infoview.open().bufnr
   local _update = vim.b.lean3 and lean3.update_infoview or function(set_lines)
-    local update = function(goal, term_goal)
-      local lines = {}
-
-      if type(goal) == "table" and goal.goals then
-        vim.list_extend(lines,
-          {#goal.goals == 0 and '▶ goals accomplished 🎉' or
-            #goal.goals == 1 and '▶ 1 goal' or
-            string.format('▶ %d goals', #goal.goals)})
-        for _, each in pairs(goal.goals) do
-          vim.list_extend(lines, {''})
-          vim.list_extend(lines, vim.split(each, '\n', true))
-        end
-      end
-
-      if type(term_goal) == "table" and term_goal.goal then
-        local start = term_goal.range["start"]
-        local end_ = term_goal.range["end"]
-        vim.list_extend(lines, {'', string.format('▶ expected type (%d:%d-%d:%d)',
-          start.line+1, start.character+1, end_.line+1, end_.character+1)})
-        vim.list_extend(lines, vim.split(term_goal.goal, '\n', true))
-      end
-
-      for _, diag in pairs(vim.lsp.diagnostic.get_line_diagnostics()) do
-        local start = diag.range["start"]
-        local end_ = diag.range["end"]
-        vim.list_extend(lines, {'', string.format('▶ %d:%d-%d:%d: %s:',
-          start.line+1, start.character+1, end_.line+1, end_.character+1, _SEVERITY[diag.severity])})
-        vim.list_extend(lines, vim.split(diag.message, '\n', true))
-      end
-
-      set_lines(lines)
-    end
     return leanlsp.plain_goal(0, function(_, _, goal)
       leanlsp.plain_term_goal(0, function(_, _, term_goal)
-        update(goal, term_goal)
+        local lines = components.goal(goal)
+        table.insert(lines, '')
+        vim.list_extend(lines, components.term_goal(term_goal))
+        vim.list_extend(lines, components.diagnostics())
+        set_lines(lines)
       end)
     end)
   end

--- a/lua/lean/infoview.lua
+++ b/lua/lean/infoview.lua
@@ -40,6 +40,8 @@ function infoview.update()
   end
 
   return _update(function(lines)
+    if vim.tbl_isempty(lines) then lines = { "No info found. " } end
+
     vim.api.nvim_buf_set_option(infoview_bufnr, 'modifiable', true)
     vim.api.nvim_buf_set_lines(infoview_bufnr, 0, -1, true, lines)
     -- HACK: This shouldn't really do anything, but I think there's a neovim

--- a/lua/lean/infoview.lua
+++ b/lua/lean/infoview.lua
@@ -5,6 +5,7 @@ local set_augroup = require('lean._nvimapi').set_augroup
 
 local infoview = {_infoviews = {}, _opts = {}}
 
+local _NOTHING_TO_SHOW = { "No info found." }
 local _INFOVIEW_BUF_NAME = 'lean://infoview'
 local _DEFAULT_BUF_OPTIONS = {
   bufhidden = 'wipe',
@@ -40,7 +41,7 @@ function infoview.update()
   end
 
   return _update(function(lines)
-    if vim.tbl_isempty(lines) then lines = { "No info found. " } end
+    if vim.tbl_isempty(lines) then lines = _NOTHING_TO_SHOW end
 
     vim.api.nvim_buf_set_option(infoview_bufnr, 'modifiable', true)
     vim.api.nvim_buf_set_lines(infoview_bufnr, 0, -1, true, lines)
@@ -162,6 +163,11 @@ function infoview.get_info_lines()
   if not infoview.is_open() then return end
   local infoview_info = infoview.open()
   return table.concat(vim.api.nvim_buf_get_lines(infoview_info.bufnr, 0, -1, true), "\n")
+end
+
+--- Is the infoview not showing anything?
+function infoview.is_empty()
+  return vim.deep_equal(infoview.get_info_lines(), _NOTHING_TO_SHOW)
 end
 
 return infoview

--- a/lua/lean/infoview/components.lua
+++ b/lua/lean/infoview/components.lua
@@ -1,0 +1,75 @@
+---@brief [[
+--- Infoview components which can be assembled to show various information
+--- about the current Lean module or state.
+---@brief ]]
+
+---@tag lean.infoview.components
+
+local DiagnosticSeverity = vim.lsp.protocol.DiagnosticSeverity
+local components = {}
+
+
+-- Format a heading.
+local function H(contents)
+  return string.format('▶ %s', contents)
+end
+
+--- The current (tactic) goal state.
+---@param goal table: a Lean4 `plainGoal` LSP response
+function components.goal(goal)
+  if type(goal) ~= "table" or not goal.goals then return {} end
+
+  local lines = {
+    #goal.goals == 0 and H('goals accomplished 🎉') or
+    #goal.goals == 1 and H('1 goal') or
+    H(string.format('%d goals', #goal.goals))
+  }
+
+  for _, each in pairs(goal.goals) do
+    vim.list_extend(lines, {''})
+    vim.list_extend(lines, vim.split(each, '\n', true))
+  end
+
+  return lines
+end
+
+--- The current (term) goal state.
+---@param term_goal table: a Lean4 `plainTermGoal` LSP response
+function components.term_goal(term_goal)
+  if type(term_goal) ~= "table" or not term_goal.goal then return {} end
+
+  local start = term_goal.range["start"]
+  local end_ = term_goal.range["end"]
+  local lines = {
+    H(string.format('expected type (%d:%d-%d:%d)',
+      start.line + 1,
+      start.character + 1,
+      end_.line + 1,
+      end_.character + 1))
+  }
+  vim.list_extend(lines, vim.split(term_goal.goal, '\n', true))
+
+  return lines
+end
+
+--- Diagnostic information for the current line from the Lean server.
+function components.diagnostics()
+  local lines = {}
+
+  for _, diag in pairs(vim.lsp.diagnostic.get_line_diagnostics()) do
+    local start = diag.range["start"]
+    local end_ = diag.range["end"]
+    vim.list_extend(lines,
+      {'', H(string.format('%d:%d-%d:%d: %s:',
+      start.line + 1,
+      start.character + 1,
+      end_.line + 1,
+      end_.character + 1,
+      DiagnosticSeverity[diag.severity]:lower()))})
+    vim.list_extend(lines, vim.split(diag.message, '\n', true))
+  end
+
+  return lines
+end
+
+return components

--- a/lua/lean/lean3.lua
+++ b/lua/lean/lean3.lua
@@ -1,22 +1,58 @@
+local components = require('lean.infoview.components')
 local lean3 = {}
+
+-- Split a Lean 3 server response on goals.
+--
+-- Looks for ⊢, but ignores indented following lines for multi-line
+-- goals.
+--
+-- Really this should also make sure ⊢ is on the
+-- start of the line via \_^, but this returns nil:
+-- `vim.regex('\\_^b'):match_str("foo\nbar\nbaz\n")` and I don't
+-- understand why; perhaps it's a neovim bug. Lua's string.gmatch also
+-- seems not powerful enough to do this.
+--
+-- Important properties of the number 2:
+--
+--    * the only even prime number
+--    * the number of problems you have after using regex to solve a problem
+local _GOAL_MARKER = vim.regex('⊢ .\\{-}\n\\(\\s\\+.\\{-}\\(\n\\|$\\)\\)*\\zs')
 
 function lean3.init()
   pcall(vim.cmd, 'TSBufDisable highlight')  -- tree-sitter-lean is lean4-only
   vim.b.lean3 = true
 end
 
+--- Convert a Lean 3 response to one that the Lean 4 server would respond with.
+local function upconvert_lsp_goal_to_lean4(response)
+  local goals = {}
+  for _, contents in ipairs(response.contents) do
+    if contents.language == 'lean' and contents.value ~= 'no goals' then
+      -- strip 'N goals' from the front (which is present for multiple goals)
+      local rest_of_goals = contents.value:gsub('^%d+ goals?\n', '')
+
+      repeat
+        local end_of_goal = _GOAL_MARKER:match_str(rest_of_goals)
+        table.insert(goals, vim.trim(rest_of_goals:sub(1, end_of_goal)))
+        if not end_of_goal then break end
+        rest_of_goals = rest_of_goals:sub(end_of_goal + 1)
+      until rest_of_goals == ""
+    end
+  end
+  return { goals = goals }
+end
+
 function lean3.update_infoview(set_lines)
   local params = vim.lsp.util.make_position_params()
   return vim.lsp.buf_request(0, "textDocument/hover", params, function(_, _, result)
-    if not (type(result) == "table" and result.contents) then
-      return
-    end
     local lines = {}
-    for _, contents in ipairs(result.contents) do
-      if contents.language == 'lean' then
-        vim.list_extend(lines, vim.split(contents.value, '\n', true))
-      end
+    if not vim.tbl_isempty(result.contents) then
+      vim.list_extend(
+        lines,
+        components.goal(upconvert_lsp_goal_to_lean4(result)))
     end
+    vim.list_extend(lines, components.diagnostics())
+
     set_lines(lines)
   end)
 end

--- a/lua/tests/infoview/lsp_spec.lua
+++ b/lua/tests/infoview/lsp_spec.lua
@@ -33,6 +33,13 @@ describe('infoview', function()
 
     it('shows term state',
     function(_)
+      -- FIXME: This wait is because this test case is the first one executed
+      --        and without it, the infoview gets updated with an empty
+      --        response if the update happens before the Lean 3 server is up.
+      --        To reproduce manually, compare:
+      --          nvim example-lean3-project/test.lean +'sleep 500m' +'normal 3gg' +'normal 23|'
+      --        with what happens without the sleep (where the window is empty).
+      vim.wait(500)
       local text = infoview_lsp_update({3, 23})
       assert.has_all(text, {"⊢ ℕ"})
     end)

--- a/lua/tests/infoview/lsp_spec.lua
+++ b/lua/tests/infoview/lsp_spec.lua
@@ -39,7 +39,7 @@ describe('infoview', function()
       --        To reproduce manually, compare:
       --          nvim example-lean3-project/test.lean +'sleep 500m' +'normal 3gg' +'normal 23|'
       --        with what happens without the sleep (where the window is empty).
-      vim.wait(500)
+      vim.wait(1000)
       local text = infoview_lsp_update({3, 23})
       assert.has_all(text, {"⊢ ℕ"})
     end)

--- a/lua/tests/infoview/lsp_spec.lua
+++ b/lua/tests/infoview/lsp_spec.lua
@@ -10,7 +10,7 @@ local function infoview_lsp_update(pos)
       -- wait for update data - will be empty if server pass incomplete
       local update_result, _ = vim.wait(500, function()
         local curr = infoview.get_info_lines()
-        if curr == before or curr == "" then return false end
+        if curr == before or infoview.is_empty() then return false end
         return true
       end)
       return update_result
@@ -33,13 +33,6 @@ describe('infoview', function()
 
     it('shows term state',
     function(_)
-      -- FIXME: This wait is because this test case is the first one executed
-      --        and without it, the infoview gets updated with an empty
-      --        response if the update happens before the Lean 3 server is up.
-      --        To reproduce manually, compare:
-      --          nvim example-lean3-project/test.lean +'sleep 500m' +'normal 3gg' +'normal 23|'
-      --        with what happens without the sleep (where the window is empty).
-      vim.wait(1000)
       local text = infoview_lsp_update({3, 23})
       assert.has_all(text, {"⊢ ℕ"})
     end)


### PR DESCRIPTION
Does so by introducing infoview components (which in the future
possibly is a way to customize what's in the infoview display).

Closes: #41
Refs: #17

@gebner if you happen to have a spare moment I wouldn't mind a sanity check on whether [this crude splitting of Lean 3 goal state](https://github.com/Julian/lean.nvim/pull/70/files#diff-11f5cd6ffbb1e3a2d6e4a3948393a130292fd3d0f7e075249a20d6ebcafdb70cR19) is trivially incorrect in some way. It seems to work for the files / state I checked manually. If not no worries, can always revert later if it goes sideways.