### PR TITLE
Increase the default memory limit in Lean3.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -187,7 +187,12 @@ In e.g. your ``init.lua``:
 
         -- Lean 3
         lsp3 = {
-            on_attach = on_attach
+            on_attach = on_attach,
+
+            -- Additional options not passed directly to lspconfig
+            --
+            -- Extra CLI arguments to pass to `lean-language-server`
+            extra_argv = { "-M", "4096" }
         },
     }
 

--- a/doc/lean.txt
+++ b/doc/lean.txt
@@ -77,6 +77,26 @@ components.diagnostics()                            *components.diagnostics()*
 
 
 ================================================================================
+lean3.init()                                                    *lean3.init()*
+    Force a buffer to be treated as Lean 3.
+
+
+
+lean3.lsp.enable({opts})                                  *lean3.lsp.enable()*
+    Enable the Lean 3 LSP. Generally called by enabling the `lsp3` section in
+    the configuration passed to `lean.setup`.
+
+
+    Parameters: ~
+        {opts} (table)  configuration options for the `lean3ls` language server
+
+    Fields: ~
+        {extra_argv} (table)  additional command line options to pass to
+                              `lean-language-server`
+
+
+
+================================================================================
 sorry.fill()                                                    *sorry.fill()*
     Fill the current cursor position with `sorry`s to discharge all goals.
 

--- a/lua/lean/init.lua
+++ b/lua/lean/init.lua
@@ -35,11 +35,11 @@ function lean.setup(opts)
   opts.infoview = opts.infoview or {}
   if opts.infoview.enable ~= false then require('lean.infoview').enable(opts.infoview) end
 
-  opts.lsp3 = opts.lsp3 or {}
-  if opts.lsp3.enable ~= false then require('lspconfig').lean3ls.setup(opts.lsp3) end
-
   opts.lsp = opts.lsp or {}
   if opts.lsp.enable ~= false then lean.lsp.enable(opts.lsp) end
+
+  opts.lsp3 = opts.lsp3 or {}
+  if opts.lsp3.enable ~= false then require('lean.lean3').lsp.enable(opts.lsp3) end
 
   opts.treesitter = opts.treesitter or {}
   if opts.treesitter.enable ~= false then require('lean.treesitter').enable(opts.treesitter) end


### PR DESCRIPTION
Matches VSCode's default found here:

https://github.com/leanprover/vscode-lean/blob/ca764c60acbfaeaca55a681bc0be65f84b0cae44/package.json#L32-L35

Possible further improvements here (which I think are slightly lower priority, but comments welcome) are to replicate something more like the VSCode settings where we have `opts.memory_limit` (and `opts.timeout`, etc.) and use those to assemble the CLI.

Or similarly to extend this to Lean4.

But really the main current issue is that the defaults aren't very usable, so I wanted to fix that ASAP.