### PR TITLE
Cancel infoview `update()` requests where necessary.

### DIFF
--- a/lua/lean/lean3.lua
+++ b/lua/lean/lean3.lua
@@ -42,19 +42,21 @@ local function upconvert_lsp_goal_to_lean4(response)
   return { goals = goals }
 end
 
-function lean3.update_infoview(set_lines)
-  local params = vim.lsp.util.make_position_params()
-  return vim.lsp.buf_request(0, "textDocument/hover", params, function(_, _, result)
-    local lines = {}
-    if result and type(result) == "table" and not vim.tbl_isempty(result.contents) then
-      vim.list_extend(
-        lines,
-        components.goal(upconvert_lsp_goal_to_lean4(result)))
-    end
-    vim.list_extend(lines, components.diagnostics())
+function lean3.update_infoview(idx)
+  return function (set_lines)
+    local params = vim.lsp.util.make_position_params()
+    return require('lean.infoview').update_request(idx)(0, "textDocument/hover", params, function(_, _, result)
+      local lines = {}
+      if result and type(result) == "table" and not vim.tbl_isempty(result.contents) then
+        vim.list_extend(
+          lines,
+          components.goal(upconvert_lsp_goal_to_lean4(result)))
+      end
+      vim.list_extend(lines, components.diagnostics())
 
-    set_lines(lines)
-  end)
+      set_lines(lines)
+    end)
+  end
 end
 
 return lean3

--- a/lua/lean/lsp.lua
+++ b/lua/lean/lsp.lua
@@ -19,18 +19,20 @@ function lsp.enable(opts)
 end
 
 -- Fetch goal state information from the server.
-function lsp.plain_goal(bufnr, handler)
+function lsp.plain_goal(bufnr, handler, request_fn)
+  request_fn = request_fn or vim.lsp.buf_request
   -- Shift forward by 1, since in vim it's easier to reach word
   -- boundaries in normal mode.
   local params = vim.lsp.util.make_position_params()
   params.position.character = params.position.character + 1
-  return vim.lsp.buf_request(bufnr, "$/lean/plainGoal", params, handler)
+  return request_fn(bufnr, "$/lean/plainGoal", params, handler)
 end
 
 -- Fetch term goal state information from the server.
-function lsp.plain_term_goal(bufnr, handler)
+function lsp.plain_term_goal(bufnr, handler, request_fn)
+  request_fn = request_fn or vim.lsp.buf_request
   local params = vim.lsp.util.make_position_params()
-  return vim.lsp.buf_request(bufnr, "$/lean/plainTermGoal", params, handler)
+  return request_fn(bufnr, "$/lean/plainTermGoal", params, handler)
 end
 
 function lsp.handlers.plain_goal_handler (_, method, result, _, _, config)

--- a/lua/tests/infoview/lsp_spec.lua
+++ b/lua/tests/infoview/lsp_spec.lua
@@ -25,6 +25,16 @@ helpers.setup {
   lsp3 = { enable = true },
 }
 describe('infoview', function()
+  it('immediate close', function()
+    vim.api.nvim_command("edit lua/tests/fixtures/example-lean3-project/test.lean")
+    helpers.wait_for_ready_lsp()
+    infoview.update()
+    infoview.close()
+    vim.wait(5000, function()
+      assert.is_not.has_match("Error", vim.api.nvim_exec("messages", true), nil, true)
+    end)
+  end)
+  infoview.open()
   it('lean 3', function()
     before_each(function()
       vim.api.nvim_command("edit lua/tests/fixtures/example-lean3-project/test.lean")
@@ -66,6 +76,7 @@ describe('infoview', function()
   local win = vim.api.nvim_get_current_win()
 
   vim.api.nvim_command("tabnew")
+  infoview.open()
 
   local winnew = vim.api.nvim_get_current_win()
 


### PR DESCRIPTION
This is a bit of a workaround instead of using the cancellation function returned by `vim.lsp.buf_request()` since it looks like the Lean servers weren't responding [to `cancelRequest`](https://github.com/neovim/neovim/blob/f35a5f2efc32b508ff5fc7d55b31a5bb7facfa17/runtime/lua/vim/lsp.lua#L958) with a [cancellation acknowledgement](https://github.com/neovim/neovim/blob/f35a5f2efc32b508ff5fc7d55b31a5bb7facfa17/runtime/lua/vim/lsp/rpc.lua#L538), which would normally [clear the callback](https://github.com/neovim/neovim/blob/f35a5f2efc32b508ff5fc7d55b31a5bb7facfa17/runtime/lua/vim/lsp/rpc.lua#L552). @gebner any plans to support this in the future?

Also #78 proved not so simple to deterministically reproduce, so leaving out a unit test for this for now.

Closes #77 and #78.