### PR TITLE
Automatically upload coverage reports on CI builds

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,67 @@
+name: Coverage
+
+on: [push, pull_request]
+
+jobs:
+  coverage:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        lean-version:
+          - "leanprover-community/lean:3.30.0"
+    steps:
+      - uses: actions/checkout@v2
+      - run: date +%F > todays-date
+      - name: Restore cache for today's nightly.
+        uses: actions/cache@v2
+        with:
+          path: |
+            _neovim
+          key: ${{ runner.os }}-x64-${{ hashFiles('todays-date') }}
+
+      - name: Install elan
+        run: |
+            curl https://raw.githubusercontent.com/Kha/elan/master/elan-init.sh -sSf | sh -s -- --default-toolchain "${{ matrix.lean-version }}" -y
+            echo "$HOME/.elan/bin/" >> $GITHUB_PATH
+        if: runner.os == 'Linux'
+
+      - name: Install neovim and elan
+        run: |
+          brew update
+          brew install --head neovim
+          brew install elan
+          elan toolchain install "${{ matrix.lean-version }}"
+          elan default "${{ matrix.lean-version }}"
+        if: runner.os == 'macOS'
+
+      - name: Build Lean 3 fixture
+        run: |
+          cd lua/tests/fixtures/example-lean3-project/ && leanpkg configure && leanpkg build
+
+      - name: Build Lean 4 fixture
+        run: |
+          cd lua/tests/fixtures/example-lean4-project/ && leanpkg configure && leanpkg build
+
+      - name: Install the Lean LSP
+        run: sudo npm install -g lean-language-server
+        if: contains(matrix.lean-version, 'lean:3')
+
+      - name: Install nvim dependencies
+        run: |
+          mkdir packpath
+          git clone --depth 1 https://github.com/neovim/nvim-lspconfig packpath/nvim-lspconfig
+          git clone --depth 1 https://github.com/norcalli/snippets.nvim packpath/snippets.nvim
+          git clone --depth 1 https://github.com/nvim-lua/plenary.nvim packpath/plenary.nvim
+
+      - name: Run tests with coverage
+        run: |
+          curl -OL https://raw.githubusercontent.com/norcalli/bot-ci/master/scripts/github-actions-setup.sh
+          source github-actions-setup.sh nightly-x64
+          make coverage
+        if: runner.os == 'Linux'
+
+      - name: Run tests
+        run: make test
+        if: runner.os == 'macOS'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -59,12 +59,8 @@ jobs:
         run: |
           curl -OL https://raw.githubusercontent.com/norcalli/bot-ci/master/scripts/github-actions-setup.sh
           source github-actions-setup.sh nightly-x64
-          make coverage
+          make install-luacov coverage
         if: runner.os == 'Linux'
-
-      - name: Run tests
-        run: make test
-        if: runner.os == 'macOS'
 
       - name: Upload to codecov.io
         run: bash <(curl -s https://codecov.io/bash) -t 1cbb8732-b172-4681-b4cb-2f11b5d70875

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -65,3 +65,6 @@ jobs:
       - name: Run tests
         run: make test
         if: runner.os == 'macOS'
+
+      - name: Upload to codecov.io
+        run: bash <(curl -s https://codecov.io/bash) -t 1cbb8732-b172-4681-b4cb-2f11b5d70875

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -55,6 +55,9 @@ jobs:
           git clone --depth 1 https://github.com/norcalli/snippets.nvim packpath/snippets.nvim
           git clone --depth 1 https://github.com/nvim-lua/plenary.nvim packpath/plenary.nvim
 
+      - name: Install luarocks
+        run: sudo apt-get install -y luarocks
+
       - name: Run tests with coverage
         run: |
           curl -OL https://raw.githubusercontent.com/norcalli/bot-ci/master/scripts/github-actions-setup.sh

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -55,8 +55,10 @@ jobs:
           git clone --depth 1 https://github.com/norcalli/snippets.nvim packpath/snippets.nvim
           git clone --depth 1 https://github.com/nvim-lua/plenary.nvim packpath/plenary.nvim
 
-      - name: Install luarocks
-        run: sudo apt-get install -y luarocks
+      - name: Install luarocks and a global luacov
+        run: |
+          sudo apt-get install -y luarocks
+          sudo luarocks install luacov
 
       - name: Run tests with coverage
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
-doc/tags
-packpath/
-/packpath
-*.olean
 leanpkg.path
+*.olean
+
+/luapath
+/packpath
+
 /lua/tests/fixtures/example-lean4-project/build
+
+doc/tags
+luacov.*.out

--- a/.luacov
+++ b/.luacov
@@ -1,0 +1,4 @@
+include = {
+    "lua/lean/.+$",
+    "lua/tests/.+$"
+}

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ test:
 
 coverage:
 	$(MAKE) LEAN_NVIM_COVERAGE=1 test
-	luapath/bin/luacov
+	luacov
 	cat luacov.report.out
 
 install-luacov:

--- a/Makefile
+++ b/Makefile
@@ -9,5 +9,14 @@ docgen:
 test:
 	nvim --headless --noplugin -u scripts/minimal_init.lua -c "PlenaryBustedDirectory lua/tests/ { minimal_init = './scripts/minimal_init.lua' }"
 
+coverage:
+	$(MAKE) LEAN_NVIM_COVERAGE=1 test
+	luapath/bin/luacov
+	cat luacov.report.out
+
+install-luacov:
+	luarocks --lua-version 5.1 install --tree luapath/ luacov
+	@echo Run 'make coverage' now to enable coverage collection.
+
 lint:
 	pre-commit run --all-files

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    patch:
+      default:
+        target: 100%

--- a/scripts/minimal_init.lua
+++ b/scripts/minimal_init.lua
@@ -10,3 +10,12 @@ vim.api.nvim_exec([[
   runtime! plugin/lspconfig.vim
   runtime! plugin/plenary.vim
 ]], false)
+
+-- plenary forks subprocesses, so enable coverage here when appropriate
+if vim.env.LEAN_NVIM_COVERAGE then
+  local luapath = lean_nvim_dir .. '/luapath'
+  package.path = package.path .. ';' .. luapath .. '/share/lua/5.1/?.lua;'
+                                     .. luapath .. '/share/lua/5.1/?/init.lua;;'
+  package.cpath = package.cpath .. ';' .. luapath .. '/lib/lua/5.1/?.so;'
+  require('luacov')
+end


### PR DESCRIPTION
First build here: https://codecov.io/gh/Julian/lean.nvim/tree/6b1fcec697c17db09dd7fbbc887b2b6673a4d1e6/lua

Obviously this is nice to have, but it's particularly nice I think because plenary's test runner is fragile -- while I was working on the infoview refactor I straight up broke `set_autoopen`, but rather than failing, tests were silently skipped by plenary because they failed in the `describe` block.

With coverage, we can at least find unexecuted test lines.

(Probably the codecov settings will need some tweaking, I never remember quite what the settings mean)