### PR TITLE
Allow for specifying a single test file to run.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ docgen:
 	nvim --headless --noplugin -u scripts/minimal_init.lua -c "luafile ./scripts/gendocs.lua" -c "qa"
 
 test:
-	nvim --headless --noplugin -u scripts/minimal_init.lua -c "PlenaryBustedDirectory lua/tests/ { minimal_init = './scripts/minimal_init.lua' }"
+	./lua/tests/scripts/run_tests.sh
 
 coverage:
 	$(MAKE) LEAN_NVIM_COVERAGE=1 test

--- a/lua/tests/scripts/run_tests.sh
+++ b/lua/tests/scripts/run_tests.sh
@@ -1,0 +1,5 @@
+if [ -z ${TEST_FILE+x} ]; then
+  nvim --headless --noplugin -u scripts/minimal_init.lua -c "PlenaryBustedDirectory lua/tests/ { minimal_init = './scripts/minimal_init.lua' }"
+else
+  nvim --headless --noplugin -u scripts/minimal_init.lua -c "PlenaryBustedFile $TEST_FILE"
+fi


### PR DESCRIPTION
Roughly follows the way this is done [in neovim's `busted` tests](https://github.com/neovim/neovim/blob/682247b52e76180e4c49b794c6cc2548bfd32d4c/cmake/RunTests.cmake#L22), that is to run a test for only a specific file you can do e.g.:

```
$ TEST_FILE=lua/tests/sorry_spec.lua make test
```