### PR TITLE
Autostart LSP for Lean 4 standard library files and make Lean 3 standard library filetype detection more robust.

### DIFF
--- a/lua/lean/lean3.lua
+++ b/lua/lean/lean3.lua
@@ -10,7 +10,7 @@ local lean3 = {}
 -- Ideally this obviously would use a TOML parser but yeah choosing to
 -- do nasty things and not add the dependency for now.
 local _PROJECT_MARKER = '.*lean_version.*\".*:3.*'
-local _STANDARD_LIBRARY_PATHS = '.*/lean--3.+/lib/'
+local _STANDARD_LIBRARY_PATHS = '.*/[^/]*lean[%-]+3.+/lib/'
 
 -- Split a Lean 3 server response on goals.
 --
@@ -31,7 +31,7 @@ local _GOAL_MARKER = vim.regex('⊢ .\\{-}\n\\(\\s\\+.\\{-}\\(\n\\|$\\)\\)*\\zs'
 
 --- Detect whether the current buffer is a Lean 3 file.
 function lean3.__detect()
-  local path = vim.api.nvim_buf_get_name(0)
+  local path = vim.fn.bufname("%")
   if path:match(_STANDARD_LIBRARY_PATHS) then return true end
 
   local project_root = find_project_root(path)

--- a/lua/lean/lsp.lua
+++ b/lua/lean/lsp.lua
@@ -37,7 +37,7 @@ end
 function lsp.handlers.definition_handler (err, method, result, client_id, bufnr, config)
   vim.lsp.handlers['textDocument/definition'](err, method, result, client_id, bufnr, config)
   -- auto-enable LSP for standard library files
-  if vim.lsp.buf_get_clients(0)[client_id] == nil and vim.bo.ft == "lean" then
+  if #vim.lsp.buf_get_clients(0) == 0 and vim.bo.ft == "lean" then
     vim.lsp.buf_attach_client(0, client_id)
   end
 end

--- a/lua/lean/lsp.lua
+++ b/lua/lean/lsp.lua
@@ -14,6 +14,7 @@ function lsp.enable(opts)
   opts.handlers = vim.tbl_extend("keep", opts.handlers or {}, {
     ["$/lean/plainGoal"] = lsp.handlers.plain_goal_handler;
     ["$/lean/plainTermGoal"] = lsp.handlers.plain_term_goal_handler;
+    ["textDocument/definition"] = lsp.handlers.definition_handler;
   })
   require('lspconfig').leanls.setup(opts)
 end
@@ -31,6 +32,14 @@ end
 function lsp.plain_term_goal(bufnr, handler)
   local params = vim.lsp.util.make_position_params()
   return vim.lsp.buf_request(bufnr, "$/lean/plainTermGoal", params, handler)
+end
+
+function lsp.handlers.definition_handler (err, method, result, client_id, bufnr, config)
+  vim.lsp.handlers['textDocument/definition'](err, method, result, client_id, bufnr, config)
+  -- auto-enable LSP for standard library files
+  if vim.lsp.buf_get_clients(0)[client_id] == nil and vim.bo.ft == "lean" then
+    vim.lsp.buf_attach_client(0, client_id)
+  end
 end
 
 function lsp.handlers.plain_goal_handler (_, method, result, _, _, config)


### PR DESCRIPTION
For Lean 3 I was getting a path like `.../.elan/toolchains/leanprover-community--lean---3.31.0/lib/...`, (yes 3 hyphens after `lean`) so I think this would be a better catch-all.

And for Lean 4 CMIIW but I don't think the server started at all for standard library files before? In Lean 3 the root finder from `nvim-lspconfig` found the `init` folder, but things are structured differently in Lean 4, so this didn't seem to work at all. Figured this was a simple enough way to do it, but of course suggestions welcome. In case you're wondering how VSCode does it, I believe it associates servers with workspaces, which are collections of (gross) UI elements, as opposed to nvim which uses root directories. 