### PR TITLE
Use `lean --version` to infer filetype when `elan` is installed.

### DIFF
--- a/lua/lean/ft.lua
+++ b/lua/lean/ft.lua
@@ -1,5 +1,12 @@
-return {
-  detect = function()
-    vim.opt.filetype = require('lean.lean3').__detect() and 'lean3' or 'lean'
+local M = {}
+if vim.fn.executable"elan" then
+  M.detect =
+  vim.schedule_wrap(function()
+    vim.opt.filetype = require('lean.lean3').__detect_elan() and 'lean3' or 'lean'
+  end)
+else
+  M.detect = function()
+    vim.opt.filetype = require('lean.lean3').__detect_regex() and 'lean3' or 'lean'
   end
-}
+end
+return M


### PR DESCRIPTION
Closes #88, ~~failed Lean 3 stdlib ft test pending leanprover/elan#36~~. Also fixed the stdlib filetype tests.