### PR TITLE
Add syntax highlighting for #reduce

### DIFF
--- a/syntax/lean.vim
+++ b/syntax/lean.vim
@@ -33,6 +33,7 @@ syn keyword leanCommand set_option run_cmd
 syn match leanCommand "#eval"
 syn match leanCommand "#check"
 syn match leanCommand "#print"
+syn match leanCommand "#reduce"
 
 syn keyword leanSorry sorry
 syn match leanSorry "#exit"

--- a/syntax/lean3.vim
+++ b/syntax/lean3.vim
@@ -33,6 +33,7 @@ syn keyword leanCommand set_option run_cmd
 syn match leanCommand "#eval"
 syn match leanCommand "#check"
 syn match leanCommand "#print"
+syn match leanCommand "#reduce"
 
 syn keyword leanSorry sorry
 syn match leanSorry "#exit"


### PR DESCRIPTION
I just started using lean.nvim, and lean in general. Could `#reduce` be highlighted the same way as `#eval` and `#check`?