### PR TITLE
Tweak infoview widgets style.

### DIFF
--- a/doc/lean.txt
+++ b/doc/lean.txt
@@ -61,6 +61,11 @@ health.check()                                                *health.check()*
 
 
 ================================================================================
+infoview.enable_debug()                              *infoview.enable_debug()*
+    Enables printing of extra debugging information in the infoview.
+
+
+
 infoview.get_current_infoview()              *infoview.get_current_infoview()*
     Get the infoview corresponding to the current window.
 

--- a/lua/lean/html.lua
+++ b/lua/lean/html.lua
@@ -422,10 +422,6 @@ end
 
 local div_ns = vim.api.nvim_create_namespace("LeanNvimInfo")
 
-vim.api.nvim_command("highlight htmlDivHighlight ctermbg=153 ctermfg=0")
-vim.api.nvim_command("highlight htmlDivLoading ctermfg=8")
-
-
 function Div:buf_get_root(buf)
   local bufdata = self.bufs[buf]
   local root, path

--- a/lua/lean/infoview.lua
+++ b/lua/lean/infoview.lua
@@ -21,6 +21,9 @@ local infoview = {
   -- mapping from pin IDs to pins
   ---@type table<number, Pin>
   _pin_by_id = {},
+  --- Whether to print additional debug information in the infoview.
+  ---@type boolean
+  debug = false,
 }
 local options = { _DEFAULTS = { autoopen = true, width = 50, autopause = false, show_processing = true,
   show_loading = true, use_widget = true, lean3 = {show_filter = true},
@@ -60,6 +63,11 @@ local Info = {}
 ---@field width number
 ---@field info Info
 local Infoview = {}
+
+--- Enables printing of extra debugging information in the infoview.
+function infoview.enable_debug()
+  infoview.debug = true
+end
 
 --- Get the infoview corresponding to the current window.
 ---@return Infoview
@@ -186,15 +194,17 @@ function Info:render()
   self.div.divs = {}
   local function render_pin(pin, current)
     local header
-    local attributes = {}
-    if current then table.insert(attributes, "CURRENT") end
-    if pin.paused then table.insert(attributes, "PAUSED") end
-    if pin.loading then table.insert(attributes, "LOADING") end
-    local attributes_txt = ""
-    for _, attribute in ipairs(attributes) do
-      attributes_txt = attributes_txt .. " [" .. attribute .. "]"
+    if infoview.debug then
+      local attributes = {}
+      if current then table.insert(attributes, "CURRENT") end
+      if pin.paused then table.insert(attributes, "PAUSED") end
+      if pin.loading then table.insert(attributes, "LOADING") end
+      local attributes_txt = ""
+      for _, attribute in ipairs(attributes) do
+        attributes_txt = attributes_txt .. " [" .. attribute .. "]"
+      end
+      header = "-- PIN " .. tostring(pin.id) .. attributes_txt
     end
-    header = "-- PIN " .. tostring(pin.id) .. attributes_txt
 
     if not current and pin.position_params then
       local bufnr = vim.fn.bufnr(vim.uri_to_fname(pin.position_params.textDocument.uri))
@@ -204,19 +214,19 @@ function Info:render()
       else
         filename = pin.position_params.textDocument.uri
       end
-      header = header .. (": file %s at line %d, character %d"):format(filename,
+      header = header and header .. ': ' or '-- '
+      header = header .. ("%s at %d:%d"):format(filename,
         pin.position_params.position.line + 1, pin.position_params.position.character + 1)
     end
     header = header and header .. "\n"
 
     local pin_div = html.Div:new({}, header, "pin_wrapper")
     if pin.div then pin_div:add_div(pin.div) end
-    if #pin.undo_list > 0 then
-      pin_div:add_div(html.Div:new({}, "\n/- undo list size: " .. tostring(#pin.undo_list) .. " -/"))
+    if infoview.debug and #pin.undo_list > 0 then
+      pin_div:add_div(html.Div:new({}, "\n-- undo list size: " .. tostring(#pin.undo_list)))
     end
 
     self.div:add_div(pin_div)
-    self.div:add_div(html.Div:new({}, "\n--", "close_pin"))
   end
 
   render_pin(self.pin, true)
@@ -225,6 +235,9 @@ function Info:render()
     self.div:add_div(html.Div:new({}, "\n\n", "pin_spacing"))
     render_pin(pin, false)
   end
+
+  -- FIXME: without the extra newline, the tests fail with obscure errors
+  self.div:insert_div({}, '\n')
 
   self:_render()
   collectgarbage()

--- a/lua/lean/infoview.lua
+++ b/lua/lean/infoview.lua
@@ -29,6 +29,7 @@ local options = { _DEFAULTS = { autoopen = true, width = 50, autopause = false, 
   show_loading = true, use_widget = true, lean3 = {show_filter = true},
   mappings = {
       ["K"] = [[click]],
+      ["<CR>"] = [[click]],
       ["I"] = [[mouse_enter]],
       ["i"] = [[mouse_leave]],
       ["u"] = [[undo]],

--- a/lua/lean/infoview/components.lua
+++ b/lua/lean/infoview/components.lua
@@ -79,6 +79,7 @@ local function code_with_infos(t, sess)
       info_div.divs = {}
       info_div:insert_div({}, "click for info!", "click-message")
       info_div.tags.event.clear = nil
+      div:insert_new_tooltip(nil)
       info_open = false
       return true
     end
@@ -127,6 +128,7 @@ local function code_with_infos(t, sess)
 
       info_div.divs = { mk_tooltip(info_popup) }
       info_div.tags.event.clear = do_reset
+      div:insert_new_tooltip(info_div)
       info_open = true
       return true
     end
@@ -145,8 +147,6 @@ local function code_with_infos(t, sess)
     div.highlightable = true
 
     div:insert_new_div(code_with_infos(t.tag[2], sess))
-
-    div:insert_new_tooltip(info_div)
   end
 
   return div

--- a/lua/lean/infoview/components.lua
+++ b/lua/lean/infoview/components.lua
@@ -189,7 +189,7 @@ function components.interactive_goals(goal, sess)
   if goal == nil then return div end
 
   div:insert_div({},
-    #goal.goals == 0 and H('goals accomplished 🎉\n') or
+    #goal.goals == 0 and H('goals accomplished 🎉') or
     #goal.goals == 1 and H('1 goal\n') or
     H(string.format('%d goals\n', #goal.goals)))
 

--- a/lua/lean/infoview/components.lua
+++ b/lua/lean/infoview/components.lua
@@ -83,6 +83,29 @@ local function code_with_infos(t, sess)
       return true
     end
 
+    ---@param info_popup InfoPopup
+    local mk_tooltip = function(info_popup)
+      local tooltip_div = html.Div:new()
+
+      if info_popup.exprExplicit ~= nil then
+        tooltip_div:insert_new_div(code_with_infos(info_popup.exprExplicit, sess))
+        if info_popup.type ~= nil then
+          tooltip_div:insert_div({}, ' :\n')
+        end
+      end
+
+      if info_popup.type ~= nil then
+        tooltip_div:insert_new_div(code_with_infos(info_popup.type, sess))
+      end
+
+      if info_popup.doc ~= nil then
+        tooltip_div:insert_div({}, '\n\n')
+        tooltip_div:insert_div({}, info_popup.doc) -- TODO: markdown
+      end
+
+      return tooltip_div
+    end
+
     local do_open_all = function(tick, render_fn)
       if render_fn then
         info_div.divs = {}
@@ -102,24 +125,7 @@ local function code_with_infos(t, sess)
         return false
       end
 
-      info_div.divs = {}
-      local keys = {}
-      for key, _ in pairs(info_popup) do
-        table.insert(keys, key)
-      end
-      table.sort(keys)
-      local prev_item = false
-      for _, key in ipairs(keys) do
-        if prev_item then
-          info_div:insert_div({}, '\n', "info-item-separator")
-        end
-        info_div:start_div({}, "", "info-item")
-        info_div:insert_div({}, key, "info-item-prefix", "leanInfoButton")
-        info_div:insert_div({}, ': ', "separator")
-        info_div:insert_new_div(code_with_infos(info_popup[key], sess))
-        info_div:end_div()
-        prev_item = true
-      end
+      info_div.divs = { mk_tooltip(info_popup) }
       info_div.tags.event.clear = do_reset
       info_open = true
       return true

--- a/syntax/leaninfo.vim
+++ b/syntax/leaninfo.vim
@@ -30,12 +30,11 @@ endif
 hi def link leanInfoComment Comment
 hi def link leanInfoBlockComment Comment
 
-highlight leanInfoHighlight ctermbg=153 ctermfg=0
-highlight leanInfoExternalHighlight ctermbg=12 ctermfg=15
-highlight leanInfoTooltip ctermbg=225 ctermfg=0
-highlight leanInfoTooltipSep ctermbg=3 ctermfg=0
-highlight leanInfoButton ctermbg=249 ctermfg=0
-highlight leanInfoField ctermbg=12 ctermfg=0
-highlight leanInfoFieldAlt ctermbg=7 ctermfg=0
-highlight leanInfoFieldSep ctermbg=225 ctermfg=4
-highlight leanInfoLoading ctermfg=8
+hi def link htmlDivHighlight DiffChange
+hi def link htmlDivLoading Comment
+
+hi def link leanInfoExternalHighlight htmlDivHighlight
+hi def link leanInfoButton Pmenu
+hi def link leanInfoField DbgCurrent
+hi def link leanInfoFieldAlt PmenuSel
+hi def link leanInfoFieldSep DbgBreakPt

--- a/syntax/leaninfo.vim
+++ b/syntax/leaninfo.vim
@@ -9,7 +9,6 @@ syn match leanInfoError "^▶.*: error:$"
 syn match leanInfoWarning "^▶.*: warning:$"
 syn match leanInfoInfo "^▶.*: information:$"
 syn match leanInfoComment "--.*"
-syn region leanInfoBlockComment start="/-" end="-/"
 
 hi def link leanInfoGoals Title
 hi def link leanInfoGoalCase Statement


### PR DESCRIPTION
 - [x] Less information by default (like pin number, undo list size, etc.)
 - [ ] Hover tooltip shows type instead of "click here"
 - [x] Map CR to click
 - [x] Clean up hover tooltip (no "exprExplicit:", etc.)
 - [x] Make highlight definitions work in GUI (only terminal colors provided atm)