### PR TITLE
Better error handling in infoview

### DIFF
--- a/lua/lean/_util.lua
+++ b/lua/lean/_util.lua
@@ -107,6 +107,9 @@ end
 
 M.a_request = a.wrap(M.request, 4)
 
+-- FIXME: tick locking is disabled for now
+-- It is really easy to crash the infoview this way if an exception is not handled.
+
 local Tick = {}
 Tick.__index = Tick
 
@@ -118,10 +121,10 @@ function Tick:check()
   -- this tick has been cancelled
   if self.ticker.tick ~= self.tick then
     -- allow waiting ticks to proceed
-    if self.ticker._lock == self.tick then
-      self.ticker._lock = false
-      self.ticker.lock_var:notify_all()
-    end
+    -- if self.ticker._lock == self.tick then
+    --   self.ticker._lock = false
+    --   self.ticker.lock_var:notify_all()
+    -- end
     return false
   end
 
@@ -132,7 +135,9 @@ local Ticker = {}
 Ticker.__index = Ticker
 
 function Ticker:new()
-  return setmetatable({tick = 0, _lock = false, lock_var = control.Condvar.new()}, self)
+  return setmetatable({tick = 0, _lock = false,
+    -- lock_var = control.Condvar.new()
+  }, self)
 end
 
 -- Updates the tick if necessary.
@@ -142,12 +147,12 @@ function Ticker:lock()
   local tick = self.tick
 
   -- if something else has the lock on this pin, wait for it to acknowlege it has been cancelled
-  while self._lock do
-    self.lock_var:wait()
-
-    -- if a new tick was created, this is cancelled
-    if self.tick ~= tick then return false end
-  end
+  -- while self._lock do
+  --   self.lock_var:wait()
+  --
+  --   -- if a new tick was created, this is cancelled
+  --   if self.tick ~= tick then return false end
+  -- end
 
   -- this is the most recent tick, so we can proceed
   self._lock = tick

--- a/lua/lean/_util.lua
+++ b/lua/lean/_util.lua
@@ -1,7 +1,7 @@
 -- Stuff that should live in some standard library.
 local Job = require("plenary.job")
 local a = require("plenary.async")
-local control = require'plenary.async.control'
+-- local control = require'plenary.async.control'
 
 local M = {}
 

--- a/lua/lean/lean3.lua
+++ b/lua/lean/lean3.lua
@@ -215,7 +215,8 @@ function lean3.update_infoview(pin, bufnr, params, use_widget, opts, options)
           local clickable_event = div_event == "click" or div_event == "change"
           if clickable_event then element_div.highlightable = true end
           events[div_event] = function(this_tick, value)
-            local args = value and { type = 'string', value = value } or { type = 'unit' }
+            local args = type(value) == 'string' and { type = 'string', value = value }
+              or { type = 'unit' }
             local success = pin:_update(false, 0, this_tick, {widget_event = {
               widget = widget,
               kind = event,


### PR DESCRIPTION
The Lean 3 widget implementation had some issues (tried to serialize a lua function as json).  This caused neovim to raise an exception, which was not handled.  Due to the exception the lock in the tick remained locked and prevented further updates, causing the infoview to hang.

This PR fixes the function serialization issue and disables the locking in the ticks because I didn't find a reliable way to handle these fatal errors.