### PR TITLE
Only set `data_div` at the very end.

### DIFF
--- a/lua/lean/lean3.lua
+++ b/lua/lean/lean3.lua
@@ -79,7 +79,7 @@ local to_event = {
   ["onChange"] = "change";
 }
 
-function lean3.update_infoview(pin, bufnr, params, use_widget, opts, options)
+function lean3.update_infoview(pin, data_div, bufnr, params, use_widget, opts, options)
   local parent_div = html.Div:new({}, "", "lean-3-widget")
   local widget
 
@@ -311,7 +311,7 @@ function lean3.update_infoview(pin, bufnr, params, use_widget, opts, options)
   if state_div then parent_div:insert_new_div(state_div) end
   parent_div:insert_new_div(components.diagnostics(bufnr, params.position.line))
 
-  pin.data_div:insert_new_div(parent_div)
+  data_div:insert_new_div(parent_div)
 
   -- update all other pins for the same URI so they aren't left with a stale "session"
   if opts and opts.widget_event then


### PR DESCRIPTION
I'm trying to scratch my brain for the real reason I added the lock, I think it had something to do with the Lean 3 infoview being left in a stale state if a replay was interrupted, but I think the dummy div used when setting loading makes it unnecessary. So I suppose you can ignore all of my cries to revert 2589253364aa3142a0b52d7dcae9c71c1d32b539 and we can do without the lock for now by simply avoiding concurrently modifying `data_div` :P

Should close #142 by fixing the race condition that I think caused it, but I'm pretty pinched on time this week so more a bit more testing would be appreciated!

Also something unrelated I noticed is that the blue highlights don't work anymore? Not sure if this was intentional.