### PR TITLE
Bind tab to enter tooltips.

### DIFF
--- a/lua/lean/html.lua
+++ b/lua/lean/html.lua
@@ -416,6 +416,7 @@ function Div:buf_register(buf, keymaps, tooltip_data)
     for key, event in pairs(keymaps) do
       mappings.n[key] = ([[<Cmd>lua require'lean.html'._by_id[%d]:buf_event(%d, "%s")<CR>]]):format(self.id, buf, event)
     end
+    mappings.n["<Tab>"] = ([[<Cmd>lua require'lean.html'._by_id[%d]:buf_enter_tooltip(%d)<CR>]]):format(self.id, buf)
     mappings.n["J"] = ([[<Cmd>lua require'lean.html'._by_id[%d]:buf_enter_tooltip(%d)<CR>]]):format(self.id, buf)
     mappings.n["S"] = ([[<Cmd>lua require'lean.html'._by_id[%d]:buf_hop_to(%d)<CR>]]):format(self.id, buf)
   end


### PR DESCRIPTION
Perhaps in preparation for shift-tab moving backwards
through them?