### PR TITLE
Fix for nil path error when first cursor position in the infoview is outside of cell boundaries

### DIFF
--- a/lua/lean/html.lua
+++ b/lua/lean/html.lua
@@ -189,7 +189,7 @@ end
 ---@return Div[]|nil @the stack of divs at this path, or nil if the path is invalid
 ---@return Div|nil @the div at this path, or nil if the path is invalid
 function Div:div_from_path(path)
-  if not path then return nil, nil end
+  if not path then print("error: div_from_path received nil path") return nil, nil end
   path = {unpack(path)}
 
   -- check that the first name matches
@@ -237,7 +237,7 @@ end
 ---@param div_stack Div[]
 ---@param check fun(div:Div):boolean
 local function _get_parent_div(div_stack, check)
-  if not div_stack then return nil, nil end
+  if not div_stack then print("error: get_parent_div received nil div stack") return nil, nil end
   div_stack = {unpack(div_stack)}
   for i = #div_stack, 1, -1 do
     local this_div = div_stack[i]

--- a/lua/lean/html.lua
+++ b/lua/lean/html.lua
@@ -189,7 +189,7 @@ end
 ---@return Div[]|nil @the stack of divs at this path, or nil if the path is invalid
 ---@return Div|nil @the div at this path, or nil if the path is invalid
 function Div:div_from_path(path)
-  if not path then print("error: div_from_path received nil path") return nil, nil end
+  if not path then error("div_from_path received nil path") return nil, nil end
   path = {unpack(path)}
 
   -- check that the first name matches
@@ -237,7 +237,7 @@ end
 ---@param div_stack Div[]
 ---@param check fun(div:Div):boolean
 local function _get_parent_div(div_stack, check)
-  if not div_stack then print("error: get_parent_div received nil div stack") return nil, nil end
+  if not div_stack then error("get_parent_div received nil div stack") return nil, nil end
   div_stack = {unpack(div_stack)}
   for i = #div_stack, 1, -1 do
     local this_div = div_stack[i]
@@ -587,6 +587,7 @@ end
 function Div:buf_hover(buf)
   local bufdata = self.bufs[buf]
   local root, path = self:buf_get_root(buf)
+  if not path then return end
 
   -- make sure this path is relative to the true root
   local function to_true_path(root_path)


### PR DESCRIPTION
@Julian does this fix the issue for you related to 4ee7e38? (It should be pretty obvious to you if it doesn't since I added error prints to the hack fix.)