### PR TITLE
Bind LocalLeader+Tab to jump into the infoview.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -159,26 +159,29 @@ either within Lean source files or within Infoview windows:
 In Lean Files
 ^^^^^^^^^^^^^
 
-+---------------------+-------------------------------------------------------+
-|        Key          |                           Function                    |
-+=====================+=======================================================+
-| ``<LocalLeader>i``  | toggle the infoview open or closed                    |
-+---------------------+-------------------------------------------------------+
-| ``<LocalLeader>p``  | pause the current infoview                            |
-+---------------------+-------------------------------------------------------+
-| ``<LocalLeader>x``  | place an infoview pin                                 |
-+---------------------+-------------------------------------------------------+
-| ``<LocalLeader>c``  | clear all current infoview pins                       |
-+---------------------+-------------------------------------------------------+
-| ``<LocalLeader>s``  | insert a ``sorry`` for each open goal                 |
-+---------------------+-------------------------------------------------------+
-| ``<LocalLeader>t``  | replace a "try this:" suggestion under the cursor     |
-+---------------------+-------------------------------------------------------+
-| ``<LocalLeader>3``  | force a buffer into Lean 3 mode                       |
-+---------------------+-------------------------------------------------------+
-| ``<LocalLeader>\\`` | show what abbreviation produces the symbol under      |
-|                     | the cursor                                            |
-+---------------------+-------------------------------------------------------+
++------------------------+----------------------------------------------------+
+|        Key             |                           Function                 |
++========================+====================================================+
+| ``<LocalLeader>i``     | toggle the infoview open or closed                 |
++------------------------+----------------------------------------------------+
+| ``<LocalLeader>p``     | pause the current infoview                         |
++------------------------+----------------------------------------------------+
+| ``<LocalLeader>x``     | place an infoview pin                              |
++------------------------+----------------------------------------------------+
+| ``<LocalLeader>c``     | clear all current infoview pins                    |
++------------------------+----------------------------------------------------+
+| ``<LocalLeader>s``     | insert a ``sorry`` for each open goal              |
++------------------------+----------------------------------------------------+
+| ``<LocalLeader>t``     | replace a "try this:" suggestion under the cursor  |
++------------------------+----------------------------------------------------+
+| ``<LocalLeader>3``     | force a buffer into Lean 3 mode                    |
++------------------------+----------------------------------------------------+
+| ``<LocalLeader><Tab>`` | jump into the infoview window associated with the  |
+|                        | current lean file (use ``:h ^Wp`` to jump back)    |
++------------------------+----------------------------------------------------+
+| ``<LocalLeader>\\``    | show what abbreviation produces the symbol under   |
+|                        | the cursor                                         |
++------------------------+----------------------------------------------------+
 
 .. note::
 

--- a/lua/lean/init.lua
+++ b/lua/lean/init.lua
@@ -24,6 +24,8 @@ local lean = {
       ["<LocalLeader>s"] = "<Cmd>lua require'lean.sorry'.fill()<CR>";
       ["<LocalLeader>t"] = "<Cmd>lua require'lean.trythis'.swap()<CR>";
       ["<LocalLeader>\\"] = "<Cmd>lua require'lean.abbreviations'.show_reverse_lookup()<CR>";
+      ["<LocalLeader><Tab>"] = "<Cmd>lua vim.api.nvim_set_current_win(" ..
+                               " require'lean.infoview'.get_current_infoview().window)<CR>";
     };
     i = {
     };


### PR DESCRIPTION
Useful particularly if there are lots of windows positioned in between
the current one and the infoview.