### PR TITLE
Use hlgroups compatible with light theme pls.

### DIFF
--- a/syntax/leaninfo.vim
+++ b/syntax/leaninfo.vim
@@ -35,6 +35,6 @@ hi def link htmlDivLoading Comment
 
 hi def link leanInfoExternalHighlight htmlDivHighlight
 hi def link leanInfoButton Pmenu
-hi def link leanInfoField DbgCurrent
-hi def link leanInfoFieldAlt PmenuSel
+hi def link leanInfoField Folded
+hi def link leanInfoFieldAlt Folded
 hi def link leanInfoFieldSep DbgBreakPt


### PR DESCRIPTION
I'm a light theme user (I'm very sorry) and the recent changes to the hlgroups cause these to be indistinct from the background for me in the tooltips. Hopefully this is a good compromise.