### PR TITLE
Define :commands.

### DIFF
--- a/lua/lean/infoview.lua
+++ b/lua/lean/infoview.lua
@@ -109,6 +109,8 @@ end
 
 --- Open this infoview if it isn't already open
 function Infoview:open()
+  if self.is_open then return end
+
   local window_before_split = vim.api.nvim_get_current_win()
 
   local win_width = vim.api.nvim_win_get_width(window_before_split)
@@ -823,6 +825,54 @@ function infoview.__maybe_autoopen()
   if not infoview._by_tabpage[tabpage] then
     infoview._by_tabpage[tabpage] = Infoview:new(options.autoopen)
   end
+end
+
+function infoview.open()
+  infoview.__maybe_autoopen()
+  infoview.get_current_infoview():open()
+end
+
+function infoview.toggle()
+  local iv = infoview.get_current_infoview()
+  if iv ~= nil then
+    iv:toggle()
+  else
+    infoview.open()
+  end
+end
+
+function infoview.pin_toggle_pause()
+  local iv = infoview.get_current_infoview()
+  if iv then iv.info.pin:toggle_pause() end
+end
+
+function infoview.add_pin()
+  infoview.open()
+  infoview.get_current_infoview().info:add_pin()
+  infoview.__update()
+end
+
+function infoview.clear_pins()
+  local iv = infoview.get_current_infoview()
+  if iv ~= nil then
+    iv.info:clear_pins()
+    infoview.__update()
+  end
+end
+
+function infoview.enable_widgets()
+  local iv = infoview.get_current_infoview()
+  if iv ~= nil then iv.info.pin:set_widget(true) end
+end
+
+function infoview.disable_widgets()
+  local iv = infoview.get_current_infoview()
+  if iv ~= nil then iv.info.pin:set_widget(false) end
+end
+
+function infoview.go_to()
+  infoview.open()
+  vim.api.nvim_set_current_win(infoview.get_current_infoview().window)
 end
 
 return infoview

--- a/lua/lean/init.lua
+++ b/lua/lean/init.lua
@@ -13,19 +13,16 @@ local subprocess_check_output = util.subprocess_check_output
 local lean = {
   mappings = {
     n = {
-      ["<LocalLeader>i"] = "<Cmd>lua require'lean.infoview'.get_current_infoview():toggle()<CR>";
-      ["<LocalLeader>p"] = "<Cmd>lua require'lean.infoview'.get_current_infoview().info.pin:toggle_pause()<CR>";
-      ["<LocalLeader>x"] = "<Cmd>lua require'lean.infoview'.get_current_infoview().info:add_pin()" ..
-                           " require'lean.infoview'.__update()<CR>";
-      ["<LocalLeader>c"] = "<Cmd>lua require'lean.infoview'.get_current_infoview().info:clear_pins()" ..
-                           " require'lean.infoview'.__update()<CR>";
-      ["<LocalLeader>w"] = "<Cmd>lua require'lean.infoview'.get_current_infoview().info.pin:set_widget(true)<CR>";
-      ["<LocalLeader>W"] = "<Cmd>lua require'lean.infoview'.get_current_infoview().info.pin:set_widget(false)<CR>";
-      ["<LocalLeader>s"] = "<Cmd>lua require'lean.sorry'.fill()<CR>";
-      ["<LocalLeader>t"] = "<Cmd>lua require'lean.trythis'.swap()<CR>";
-      ["<LocalLeader>\\"] = "<Cmd>lua require'lean.abbreviations'.show_reverse_lookup()<CR>";
-      ["<LocalLeader><Tab>"] = "<Cmd>lua vim.api.nvim_set_current_win(" ..
-                               " require'lean.infoview'.get_current_infoview().window)<CR>";
+      ["<LocalLeader>i"] = "<Cmd>LeanInfoviewToggle<CR>";
+      ["<LocalLeader>p"] = "<Cmd>LeanInfoviewPinTogglePause<CR>";
+      ["<LocalLeader>x"] = "<Cmd>LeanInfoviewAddPin<CR>";
+      ["<LocalLeader>c"] = "<Cmd>LeanInfoviewClearPins<CR>";
+      ["<LocalLeader>w"] = "<Cmd>LeanInfoviewEnableWidgets<CR>";
+      ["<LocalLeader>W"] = "<Cmd>LeanInfoviewDisableWidgets<CR>";
+      ["<LocalLeader><Tab>"] = "<Cmd>LeanGotoInfoview<CR>";
+      ["<LocalLeader>s"] = "<Cmd>LeanSorryFill<CR>";
+      ["<LocalLeader>t"] = "<Cmd>LeanTryThis<CR>";
+      ["<LocalLeader>\\"] = "<Cmd>LeanAbbreviationsReverseLookup<CR>";
     };
     i = {
     };
@@ -56,6 +53,21 @@ function lean.setup(opts)
   if opts.progress_bars.enable ~= false then require'lean.progress_bars'.enable(opts.progress_bars) end
 
   require'lean.stderr'.enable()
+
+  vim.cmd[[
+    command LeanInfoviewToggle :lua require'lean.infoview'.toggle()
+    command LeanInfoviewPinTogglePause :lua require'lean.infoview'.pin_toggle_pause()
+    command LeanInfoviewAddPin :lua require'lean.infoview'.add_pin()
+    command LeanInfoviewClearPins :lua require'lean.infoview'.clear_pins()
+    command LeanInfoviewEnableWidgets :lua require'lean.infoview'.enable_widgets()
+    command LeanInfoviewDisableWidgets :lua require'lean.infoview'.disable_widgets()
+    command LeanGotoInfoview :lua require'lean.infoview'.go_to()
+
+    command LeanAbbreviationsReverseLookup :lua require'lean.abbreviations'.show_reverse_lookup()
+
+    command LeanSorryFill :lua require'lean.sorry'.fill()
+    command LeanTryThis :lua require'lean.trythis'.swap()
+  ]]
 
   if opts.mappings == true then
     vim.cmd[[


### PR DESCRIPTION
This makes it much nicer to set up custom keybindings.  I've also taken the liberty to fix some corner cases with the infoview commands (e.g. toggle didn't reopen it if you closed it with `:q`).