### PR TITLE
Add config for default standalone lean filetype, and support for lean-toolchain files

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -240,6 +240,12 @@ Full Configuration & Settings Information
       -- Lean 3  (on_attach is as above, your LSP handler)
       lsp3 = { on_attach = on_attach },
 
+      -- What filetype should be associated with standalone Lean files?
+      -- Can be set to "lean3" if you prefer that default.
+      -- Having a leanpkg.toml or lean-toolchain file should always mean
+      -- autodetection works correctly.
+      ft = { default = "lean" },
+
       -- Abbreviation support
       abbreviations = {
         -- Set one of the following to true to enable abbreviations

--- a/lua/lean/ft.lua
+++ b/lua/lean/ft.lua
@@ -1,5 +1,52 @@
-local M = {}
-M.detect = function(filename)
-  vim.opt.filetype = require('lean.lean3').__detect_regex(filename) and 'lean3' or 'lean'
+local ft = {}
+local options = { _DEFAULTS = { default = "lean" } }
+
+local _LEAN3_STANDARD_LIBRARY = '.*/[^/]*lean[%-]+3.+/lib/'
+local _LEAN3_VERSION_MARKER = '.*lean_version.*\".*:3.*'
+local _LEAN4_VERSION_MARKER = '.*lean_version.*\".*lean4:.*'
+
+local find_project_root = require('lspconfig.util').root_pattern(
+  'leanpkg.toml',
+  'lakefile.lean',
+  'lean-toolchain'
+)
+
+function ft.detect(filename)
+  local abspath = vim.fn.fnamemodify(filename, ":p")
+  local filetype = options.default
+  if abspath:match(_LEAN3_STANDARD_LIBRARY) then
+    filetype = 'lean3'
+  else
+    local project_root = find_project_root(abspath)
+    local succeeded, result
+    if project_root then
+      succeeded, result = pcall(vim.fn.readfile, project_root .. '/lean-toolchain')
+      if succeeded then
+        if result[1]:match('.*:3.*') then filetype = 'lean3'
+        elseif result[1]:match('.*lean4:.*') then filetype = 'lean'
+        end
+      else
+        succeeded, result = pcall(vim.fn.readfile, project_root .. '/leanpkg.toml')
+        if succeeded then
+          for _, line in ipairs(result) do
+            if line:match(_LEAN3_VERSION_MARKER) then
+              filetype = 'lean3'
+              break
+            end
+            if line:match(_LEAN4_VERSION_MARKER) then
+              filetype = 'lean'
+              break
+            end
+          end
+        end
+      end
+    end
+  end
+  vim.opt.filetype = filetype
 end
-return M
+
+function ft.enable(opts)
+  options = vim.tbl_extend("force", options._DEFAULTS, opts)
+end
+
+return ft

--- a/lua/lean/init.lua
+++ b/lua/lean/init.lua
@@ -52,6 +52,7 @@ function lean.setup(opts)
   opts.progress_bars = opts.progress_bars or {}
   if opts.progress_bars.enable ~= false then require'lean.progress_bars'.enable(opts.progress_bars) end
 
+  require'lean.ft'.enable(opts.ft or {})
   require'lean.stderr'.enable()
 
   vim.cmd[[

--- a/lua/lean/lean3.lua
+++ b/lua/lean/lean3.lua
@@ -1,7 +1,6 @@
-local find_project_root = require('lspconfig.util').root_pattern('leanpkg.toml')
 local dirname = require('lspconfig.util').path.dirname
 
-local util = require"lean._util"
+local util = require'lean._util'
 local lsp = require'lean.lsp'
 local components = require('lean.infoview.components')
 local subprocess_check_output = util.subprocess_check_output
@@ -10,29 +9,6 @@ local html = require('lean.html')
 
 local lean3 = {}
 
--- Ideally this obviously would use a TOML parser but yeah choosing to
--- do nasty things and not add the dependency for now.
-local _PROJECT_MARKER = '.*lean_version.*\".*:3.*'
-local _STANDARD_LIBRARY_PATHS = '.*/[^/]*lean[%-]+3.+/lib/'
-
---- Detect whether the current buffer is a Lean 3 file using regex matching.
-function lean3.__detect_regex(filename)
-  local bufnr = vim.fn.bufnr(filename)
-  if bufnr == -1 then return end
-
-  local path = vim.uri_to_fname(vim.uri_from_bufnr(bufnr))
-  if path:match(_STANDARD_LIBRARY_PATHS) then return true end
-
-  local project_root = find_project_root(path)
-  if project_root then
-    local result = vim.fn.readfile(project_root .. '/leanpkg.toml')
-    for _, line in ipairs(result) do
-      if line:match(_PROJECT_MARKER) then return true end
-    end
-  end
-
-  return false
-end
 
 --- Detect whether the current buffer is a Lean 3 file using elan.
 function lean3.__detect_elan(filename)


### PR DESCRIPTION
An attempt at solution 3 from #170's comments, as well as support for `lean-toolchain` files.

Seems to work in manual testing and pass our current tests, but I've only played with it for a few minutes.

Of course let me know if it doesn't work on your setups (or if you have general comments).