### PR TITLE
Use separate buffer for stderr messages.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -301,6 +301,9 @@ Full Configuration & Settings Information
         -- Use a different priority for the signs
         priority = 10,
       },
+
+      -- Print Lean's stderr messages to a vim buffer
+      stderr = { enable = true },
     }
 
 Other Plugins

--- a/lua/lean/infoview.lua
+++ b/lua/lean/infoview.lua
@@ -78,6 +78,8 @@ local Info = {}
 ---@field width number
 ---@field height number
 ---@field info Info
+---@field window integer
+---@field orientation "vertical"|"horizontal"
 local Infoview = {}
 
 local pin_hl_group = "LeanNvimPin"

--- a/lua/lean/init.lua
+++ b/lua/lean/init.lua
@@ -57,7 +57,10 @@ function lean.setup(opts)
   if opts.progress_bars.enable ~= false then require'lean.progress_bars'.enable(opts.progress_bars) end
 
   require'lean.ft'.enable(opts.ft or {})
-  require'lean.stderr'.enable()
+
+  if not opts.stderr or opts.stderr.enable then
+    require'lean.stderr'.enable()
+  end
 
   vim.cmd[[
     command LeanInfoviewToggle :lua require'lean.infoview'.toggle()

--- a/lua/lean/stderr.lua
+++ b/lua/lean/stderr.lua
@@ -1,17 +1,61 @@
 local log = require'vim.lsp.log'
+local infoview = require'lean.infoview'
 local stderr = {}
 
--- Show stderr output in :messages
+-- Opens a window for the stderr buffer.
+local function open_window(stderr_bufnr)
+  local old_win = vim.api.nvim_get_current_win()
+
+  -- split the infoview window if open
+  local iv = infoview.get_current_infoview()
+  if iv and iv.window and vim.api.nvim_win_is_valid(iv.window) then
+    vim.api.nvim_set_current_win(iv.window)
+    vim.cmd(('rightbelow sbuffer %d'):format(stderr_bufnr))
+  else
+    vim.cmd(('botright sbuffer %d'):format(stderr_bufnr))
+  end
+
+  vim.cmd'resize 5'
+  local stderr_winnr = vim.api.nvim_get_current_win()
+  vim.opt_local.number = true
+  vim.opt_local.bufhidden = 'hide'
+  vim.opt_local.spell = false
+  vim.opt_local.undolevels = -1
+  vim.opt_local.signcolumn = 'no'
+
+  vim.api.nvim_set_current_win(old_win)
+
+  return stderr_winnr
+end
+
+-- Show stderr output in separate buffer
 -- TODO: add upstream neovim API
 function stderr.enable()
   local old_error = log.error
+  local stderr_bufnr, stderr_winnr
   log.error = function(...)
     local argc = select('#', ...)
     if argc == 0 then return true end -- always enable error messages
     if argc == 4 and select(1, ...) == 'rpc' and select(3, ...) == 'stderr'
         and string.match(select(2, ...), 'lean') then
       local chunk = select(4, ...)
-      vim.schedule(function() vim.api.nvim_err_writeln(chunk) end)
+      vim.schedule(function()
+        if not stderr_bufnr or not vim.api.nvim_buf_is_valid(stderr_bufnr) then
+          stderr_bufnr = vim.api.nvim_create_buf(false, true)
+          vim.api.nvim_buf_set_name(stderr_bufnr, "lean://stderr")
+          stderr_winnr = nil
+        end
+        if not stderr_winnr or not vim.api.nvim_win_is_valid(stderr_winnr) then
+          stderr_winnr = open_window(stderr_bufnr)
+        end
+        local lines = vim.split(chunk, '\n')
+        local num_lines = vim.api.nvim_buf_line_count(stderr_bufnr)
+        if lines[#lines] == '' then table.remove(lines) end
+        vim.api.nvim_buf_set_lines(stderr_bufnr, num_lines, num_lines, false, lines)
+        if vim.api.nvim_get_current_win() ~= stderr_winnr then
+          vim.api.nvim_win_set_cursor(stderr_winnr, {num_lines, 0})
+        end
+      end)
     end
     old_error(...)
   end

--- a/lua/tests/helpers.lua
+++ b/lua/tests/helpers.lua
@@ -25,6 +25,7 @@ local default_config = {
     show_processing = false,
     lean3 = { show_filter = false }
   },
+  stderr = { enable = false },
   lsp3 = {
     enable = false
   },


### PR DESCRIPTION
See also #148.  Printing stderr to `:messages` is extremely annoying when there's a constant stream of messages (such as when the server panics on certain syntax, like https://github.com/leanprover/lean4/issues/776) because `:messages` steals the focus and you can't type anymore.  This PR insteads opens a new `lean://stderr` buffer and prints the stderr output there.

I've thought about putting the stderr output in the infoview as discussed in #148 but I don't think that's a good idea since we want to reduce the amount of infoview updates (as in #190).

The buffer is disabled in the tests because it also shows that elan is downloading a new lean version (which is on stderr and happens in the tests).