### PR TITLE
Implement cursor events and use to get Lean 3 click higlighting.

### DIFF
--- a/lua/lean/html.lua
+++ b/lua/lean/html.lua
@@ -250,7 +250,7 @@ end
 ---@class DivEventContext
 ---@field rerender fun()
 ---@field rehover fun()
----@field root BufDiv
+---@field self BufDiv
 
 ---Trigger the given event at the given path
 ---@param path PathNode[] @the path to trigger the event at

--- a/lua/lean/html.lua
+++ b/lua/lean/html.lua
@@ -491,7 +491,7 @@ function BufDiv:buf_update_position()
   self.path = self.div:path_from_pos(raw_pos)
 
   if not path_equal(path_before, self.path) then
-    self:buf_event("cursor_leave", path_before, function() self:buf_event("cursor_enter") end)
+    self:buf_event("cursor_leave", path_before)
     self:buf_event("cursor_enter", self.path)
     return true
   end
@@ -612,7 +612,7 @@ function BufDiv:buf_make_event_context()
   return {
     rerender = function() self:buf_render() end,
     rehover = function() self:buf_hover() end,
-    root = self,
+    self = self,
   }
 end
 

--- a/lua/lean/html.lua
+++ b/lua/lean/html.lua
@@ -490,7 +490,13 @@ function BufDiv:buf_update_position()
 
   self.path = self.div:path_from_pos(raw_pos)
 
-  return not path_equal(path_before, self.path)
+  if not path_equal(path_before, self.path) then
+    self:buf_event("cursor_left", path_before, function() self:buf_event("cursor_entered") end)
+    self:buf_event("cursor_entered", self.path)
+    return true
+  end
+
+  return false
 end
 
 function BufDiv:buf_hover(force_update_highlight)

--- a/lua/lean/html.lua
+++ b/lua/lean/html.lua
@@ -491,8 +491,8 @@ function BufDiv:buf_update_position()
   self.path = self.div:path_from_pos(raw_pos)
 
   if not path_equal(path_before, self.path) then
-    self:buf_event("cursor_left", path_before, function() self:buf_event("cursor_entered") end)
-    self:buf_event("cursor_entered", self.path)
+    self:buf_event("cursor_leave", path_before, function() self:buf_event("cursor_enter") end)
+    self:buf_event("cursor_enter", self.path)
     return true
   end
 

--- a/lua/lean/infoview.lua
+++ b/lua/lean/infoview.lua
@@ -42,8 +42,6 @@ local options = {
       ["K"] = [[click]],
       ["<CR>"] = [[click]],
       ["<Esc>"] = 'clear_all',
-      ["I"] = [[mouse_enter]],
-      ["i"] = [[mouse_leave]],
       ["C"] = 'clear_all',
       ["<LocalLeader><Tab>"] = [[goto_last_window]]
     }
@@ -503,7 +501,7 @@ function Pin:set_loading(loading)
   return false
 end
 
-Pin.update = a.void(function(self, force, delay, _, lean3_opts)
+function Pin:a_update(force, delay, _, lean3_opts)
   if not force and self.paused then return end
 
   local tick = self.ticker:lock()
@@ -514,7 +512,9 @@ Pin.update = a.void(function(self, force, delay, _, lean3_opts)
   if not self:set_loading(false) then
     self:render_parents()
   end
-end)
+end
+
+Pin.update = a.void(Pin.a_update)
 
 function Pin:_update(force, delay, tick, lean3_opts)
   if self.position_params and (force or not self.paused) then

--- a/lua/lean/infoview.lua
+++ b/lua/lean/infoview.lua
@@ -501,7 +501,7 @@ function Pin:set_loading(loading)
   return false
 end
 
-function Pin:a_update(force, delay, _, lean3_opts)
+function Pin:async_update(force, delay, _, lean3_opts)
   if not force and self.paused then return end
 
   local tick = self.ticker:lock()
@@ -514,7 +514,7 @@ function Pin:a_update(force, delay, _, lean3_opts)
   end
 end
 
-Pin.update = a.void(Pin.a_update)
+Pin.update = a.void(Pin.async_update)
 
 function Pin:_update(force, delay, tick, lean3_opts)
   if self.position_params and (force or not self.paused) then

--- a/lua/lean/infoview.lua
+++ b/lua/lean/infoview.lua
@@ -637,7 +637,7 @@ function Pin:__update(tick, delay, lean3_opts)
   end
 
   new_data_div.events.clear_all = function(ctx) ---@param ctx DivEventContext
-    vim.api.nvim_set_current_win(ctx.root.last_win)
+    vim.api.nvim_set_current_win(ctx.self.last_win)
     new_data_div:find(function (div) ---@param div Div
       if div.events.clear then div.events.clear(ctx) end
     end)

--- a/lua/lean/lean3.lua
+++ b/lua/lean/lean3.lua
@@ -49,8 +49,8 @@ local class_to_hlgroup = {
 
 -- mapping from lean3 events to standard div events
 local to_event = {
-  ["onMouseEnter"] = "mouse_enter";
-  ["onMouseLeave"] = "mouse_leave";
+  ["onMouseEnter"] = "cursor_entered";
+  ["onMouseLeave"] = "cursor_left";
   ["onClick"] = "click";
   ["onChange"] = "change";
 }
@@ -215,13 +215,17 @@ function lean3.update_infoview(pin, data_div, bufnr, params, use_widget,
           events[div_event] = function(ctx, value)
             local args = type(value) == 'string' and { type = 'string', value = value }
               or { type = 'unit' }
-            pin:update(false, 0, ctx, {widget_event = {
+            pin:a_update(false, 0, ctx, {widget_event = {
               widget = widget,
               kind = event,
               handler = handler,
               args = args,
               textDocument = pin.position_params.textDocument
             }})
+            -- trigger cursor_entered
+            if div_event == "cursor_left" then
+              value()
+            end
           end
         end
       end

--- a/lua/lean/lean3.lua
+++ b/lua/lean/lean3.lua
@@ -49,8 +49,8 @@ local class_to_hlgroup = {
 
 -- mapping from lean3 events to standard div events
 local to_event = {
-  ["onMouseEnter"] = "cursor_entered";
-  ["onMouseLeave"] = "cursor_left";
+  ["onMouseEnter"] = "cursor_enter";
+  ["onMouseLeave"] = "cursor_leave";
   ["onClick"] = "click";
   ["onChange"] = "change";
 }
@@ -215,15 +215,15 @@ function lean3.update_infoview(pin, data_div, bufnr, params, use_widget,
           events[div_event] = function(ctx, value)
             local args = type(value) == 'string' and { type = 'string', value = value }
               or { type = 'unit' }
-            pin:a_update(false, 0, ctx, {widget_event = {
+            pin:async_update(false, 0, ctx, {widget_event = {
               widget = widget,
               kind = event,
               handler = handler,
               args = args,
               textDocument = pin.position_params.textDocument
             }})
-            -- trigger cursor_entered
-            if div_event == "cursor_left" then
+            -- trigger cursor_enter
+            if div_event == "cursor_leave" then
               value()
             end
           end

--- a/lua/lean/lean3.lua
+++ b/lua/lean/lean3.lua
@@ -222,9 +222,8 @@ function lean3.update_infoview(pin, data_div, bufnr, params, use_widget,
               args = args,
               textDocument = pin.position_params.textDocument
             }})
-            -- trigger cursor_enter
             if div_event == "cursor_leave" then
-              value()
+              ctx.self:buf_event("cursor_enter")
             end
           end
         end


### PR DESCRIPTION
This is very useful for precedence hints. We technically already had this with the `I`/`i` keybindings but this makes it automatic. @gebner this should also make it easy to implement #166 (though I'd like this to be configurable).