### PR TITLE
Add support for Lean scratch buffers.

### DIFF
--- a/lua/lean/init.lua
+++ b/lua/lean/init.lua
@@ -92,6 +92,24 @@ function lean.is_lean_buffer()
   return filetype == "lean" or filetype == "lean3"
 end
 
+function lean.open_scratch_buffer()
+  if not lean.is_lean_buffer() then return end
+  local pos = vim.api.nvim_win_get_cursor(0)
+  local lines = vim.api.nvim_buf_get_lines(0, 0, -1, true)
+
+  local _, _, curr_name = vim.api.nvim_buf_get_name(0):find("(.*)%.lean")
+  local scratch_buf_name = curr_name .. "_scratch.lean"
+  local scratch_buf_uri = vim.uri_from_fname(scratch_buf_name)
+
+  local bufnr = vim.uri_to_bufnr(scratch_buf_uri)
+  vim.api.nvim_buf_set_option(bufnr, 'modifiable', true)
+  vim.api.nvim_win_set_buf(0, bufnr)
+
+  vim.api.nvim_buf_set_lines(0, 0, -1, true, lines)
+
+  vim.api.nvim_win_set_cursor(0, pos)
+end
+
 --- Return the current Lean search path.
 ---
 --- Includes both the Lean core libraries as well as project-specific

--- a/lua/lean/init.lua
+++ b/lua/lean/init.lua
@@ -103,6 +103,7 @@ function lean.open_scratch_buffer()
 
   local bufnr = vim.uri_to_bufnr(scratch_buf_uri)
   vim.api.nvim_buf_set_option(bufnr, 'modifiable', true)
+  vim.api.nvim_buf_set_option(bufnr, 'buftype', 'nowrite')
   vim.api.nvim_win_set_buf(0, bufnr)
 
   vim.api.nvim_buf_set_lines(0, 0, -1, true, lines)

--- a/lua/lean/lean3.lua
+++ b/lua/lean/lean3.lua
@@ -349,6 +349,12 @@ function lean3.lsp_enable(opts)
       vim.lsp.handlers['textDocument/publishDiagnostics'](...)
     end;
   })
+  opts.commands = vim.tbl_extend("keep", opts.commands or {}, {
+    LeanScratchBuffer = {
+      function() require"lean".open_scratch_buffer() end,
+      description = "Open a scratch buffer for the currently open Lean file."
+    };
+  })
   require'lspconfig'.lean3ls.setup(opts)
 end
 

--- a/lua/lean/lsp.lua
+++ b/lua/lean/lsp.lua
@@ -11,6 +11,10 @@ function lsp.enable(opts)
       function (...) lsp.plain_term_goal(vim.lsp.util.make_position_params(), ...) end;
       description = "Describe the expected type of the current term."
     };
+    LeanScratchBuffer = {
+      function() require"lean".open_scratch_buffer() end,
+      description = "Open a scratch buffer for the currently open Lean file."
+    };
   })
   opts.handlers = vim.tbl_extend("keep", opts.handlers or {}, {
     ["$/lean/plainGoal"] = util.mk_handler(lsp.handlers.plain_goal_handler);


### PR DESCRIPTION
This is a companion to #193. Sometimes I want to mess around with a Lean 3 file without causing all of the dependent files to have to reload. So what this does is just copy the text into a modifiable file with the same name and the postfix "_scratch.lean". Let me know if there's some other way I'm unaware of.