### PR TITLE
Add support for Lake to current_search_paths.

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Build Lean 4 fixture
         run: |
-          cd lua/tests/fixtures/example-lean4-project/ && leanpkg configure && leanpkg build
+          cd lua/tests/fixtures/example-lean4-project/ && lake build
 
       - name: Install the Lean LSP
         run: sudo npm install -g lean-language-server

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ docgen:
 
 build-test-fixtures:
 	cd ./lua/tests/fixtures/example-lean3-project/ && leanpkg build
-	cd ./lua/tests/fixtures/example-lean4-project/ && leanpkg build
+	cd ./lua/tests/fixtures/example-lean4-project/ && lake build
 
 test: build-test-fixtures
 	./lua/tests/scripts/run_tests.sh

--- a/lua/lean/init.lua
+++ b/lua/lean/init.lua
@@ -103,10 +103,16 @@ function lean.current_search_paths()
     paths = require'lean.lean3'.__current_search_paths()
   else
     local root = util.list_workspace_folders()[1]
-    -- print-paths emits a colon-separated list of .lean paths on the second line
+    if not root then root = vim.fn.getcwd() end
+
+    local executable = (
+        vim.loop.fs_stat(root .. '/' .. 'lakefile.lean')
+         or not vim.loop.fs_stat(root .. '/' .. 'leanpkg.toml')
+    ) and "lake" or "leanpkg"
+
     local all_paths = vim.fn.json_decode(
       subprocess_check_output{
-        command = "leanpkg", args = {"print-paths"}, cwd = root
+        command = executable, args = {"print-paths"}, cwd = root
     })
     paths = vim.tbl_map(function(path) return root .. '/' .. path end, all_paths.srcPath)
     vim.list_extend(

--- a/lua/tests/fixtures/example-lean4-project/foo/lakefile.lean
+++ b/lua/tests/fixtures/example-lean4-project/foo/lakefile.lean
@@ -1,0 +1,6 @@
+import Lake
+open Lake DSL
+
+package foo {
+  defaultFacet := PackageFacet.oleans,
+}

--- a/lua/tests/fixtures/example-lean4-project/foo/lean-toolchain
+++ b/lua/tests/fixtures/example-lean4-project/foo/lean-toolchain
@@ -1,0 +1,1 @@
+leanprover/lean4:master

--- a/lua/tests/fixtures/example-lean4-project/foo/leanpkg.toml
+++ b/lua/tests/fixtures/example-lean4-project/foo/leanpkg.toml
@@ -1,4 +1,0 @@
-[package]
-name = "Foo"
-version = "0.1"
-lean_version = "leanprover/lean4:nightly-2021-08-30"

--- a/lua/tests/fixtures/example-lean4-project/lakefile.lean
+++ b/lua/tests/fixtures/example-lean4-project/lakefile.lean
@@ -1,0 +1,10 @@
+import Lake
+open Lake DSL
+
+package Test {
+  defaultFacet := PackageFacet.oleans,
+  dependencies := #[{
+    name := `foo
+    src := Source.path ("foo")
+  }]
+}

--- a/lua/tests/fixtures/example-lean4-project/lean-toolchain
+++ b/lua/tests/fixtures/example-lean4-project/lean-toolchain
@@ -1,0 +1,1 @@
+leanprover/lean4:nightly-2021-10-28

--- a/lua/tests/fixtures/example-lean4-project/leanpkg.toml
+++ b/lua/tests/fixtures/example-lean4-project/leanpkg.toml
@@ -1,7 +1,0 @@
-[package]
-name = "test"
-version = "0.1"
-lean_version = "leanprover/lean4:nightly-2021-10-13"
-
-[dependencies]
-Foo = { path = "foo" }


### PR DESCRIPTION
Support for leanpkg.toml files for Lean 4 is for now left in place (but
only is used when there's no lakefile.lean).

Closes: #194

Refs: neovim/nvim-lspconfig#1390