### PR TITLE
Implement state diffs.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -172,6 +172,8 @@ In Lean Files
 +------------------------+----------------------------------------------------+
 | ``<LocalLeader>dc``    | clear current infoview diff pin                    |
 +------------------------+----------------------------------------------------+
+| ``<LocalLeader>dd``    | toggle auto diff pin mode                          |
++------------------------+----------------------------------------------------+
 | ``<LocalLeader>s``     | insert a ``sorry`` for each open goal              |
 +------------------------+----------------------------------------------------+
 | ``<LocalLeader>t``     | replace a "try this:" suggestion under the cursor  |

--- a/README.rst
+++ b/README.rst
@@ -168,6 +168,10 @@ In Lean Files
 +------------------------+----------------------------------------------------+
 | ``<LocalLeader>c``     | clear all current infoview pins                    |
 +------------------------+----------------------------------------------------+
+| ``<LocalLeader>dx``    | place an infoview diff pin                         |
++------------------------+----------------------------------------------------+
+| ``<LocalLeader>dc``    | clear current infoview diff pin                    |
++------------------------+----------------------------------------------------+
 | ``<LocalLeader>s``     | insert a ``sorry`` for each open goal              |
 +------------------------+----------------------------------------------------+
 | ``<LocalLeader>t``     | replace a "try this:" suggestion under the cursor  |

--- a/ftplugin/leaninfo/infoview.lua
+++ b/ftplugin/leaninfo/infoview.lua
@@ -4,6 +4,7 @@ vim.opt_local.cursorline = false
 vim.opt_local.number = false
 vim.opt_local.relativenumber = false
 vim.opt_local.spell = false
+vim.opt_local.winfixheight = true
 vim.opt_local.winfixwidth = true
 vim.opt_local.wrap = true
 vim.opt_local.undolevels = -1

--- a/lua/lean/_util.lua
+++ b/lua/lean/_util.lua
@@ -196,6 +196,22 @@ function M.list_workspace_folders()
   return workspace_folders
 end
 
+function M.position_params_valid(params)
+  local bufnr = vim.fn.bufnr(vim.uri_to_fname(params.textDocument.uri))
+  if bufnr == -1 then return false end
+
+  local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, true)
+
+  local line = params.position.line + 1
+  local col = params.position.character + 1
+
+  if line > #lines then return false end
+
+  if col > vim.fn.strwidth(lines[line]) then return false end
+
+  return true
+end
+
 M.wait_timer = a.wrap(function(timeout, handler) vim.defer_fn(handler, timeout) end, 2)
 
 return M

--- a/lua/lean/html.lua
+++ b/lua/lean/html.lua
@@ -338,11 +338,14 @@ BufDiv.__index = BufDiv
 local _by_id = setmetatable({}, {__mode = 'v'})
 local next_id = 1
 
----@param buf integer
+---@param buf_name string
 ---@param keymaps? table Extra keymaps
-function BufDiv:new(buf, div, keymaps)
+function BufDiv:new(buf_name, div, keymaps)
   local id = next_id
   next_id = next_id + 1
+  local buf = vim.api.nvim_create_buf(false, true)
+  if buf_name then vim.api.nvim_buf_set_name(buf, buf_name) end
+  vim.api.nvim_buf_set_option(buf, "modifiable", false)
   local new_bufdiv = setmetatable({
     id = id,
     buf = buf,
@@ -538,11 +541,8 @@ function BufDiv:buf_hover(force_update_highlight)
     if self.tooltip then -- reuse old tooltip window
       self.tooltip.div = new_tooltip_div
     else
-      local tooltip_buf = vim.api.nvim_create_buf(false, true)
-      vim.api.nvim_buf_set_option(tooltip_buf, "bufhidden", "wipe")
-      vim.api.nvim_buf_set_option(tooltip_buf, "modifiable", false)
-
-      self.tooltip = BufDiv:new(tooltip_buf, new_tooltip_div, self.keymaps)
+      self.tooltip = BufDiv:new(nil, new_tooltip_div, self.keymaps)
+      vim.api.nvim_buf_set_option(self.tooltip.buf, "bufhidden", "wipe")
     end
 
     self.tooltip.parent = self

--- a/lua/lean/infoview.lua
+++ b/lua/lean/infoview.lua
@@ -398,6 +398,25 @@ function Info:render()
   collectgarbage()
 end
 
+--- Move the current pin to the specified location.
+function Info:move_pin(params)
+  if self.auto_diff_pin and self.pin.position_params then
+    -- update diff pin to previous position
+    self:add_diff_pin(self.pin.position_params)
+  end
+  if params then self.pin:move(params) end
+end
+
+function Info:toggle_auto_diff_pin()
+  if self.auto_diff_pin then
+    self.auto_diff_pin = false
+    self:clear_diff_pin()
+  else
+    self.auto_diff_pin = true
+    self:move_pin()
+  end
+end
+
 function Info:_render()
   self.bufdiv:buf_render()
 
@@ -781,7 +800,7 @@ end
 function infoview.__update()
   if not is_lean_buffer() then return end
   infoview.get_current_infoview().info:set_last_window()
-  infoview.get_current_infoview().info.pin:move(vim.lsp.util.make_position_params())
+  infoview.get_current_infoview().info:move_pin(vim.lsp.util.make_position_params())
 end
 
 --- Update pins corresponding to the given URI.
@@ -910,6 +929,12 @@ function infoview.clear_diff_pin()
   if iv ~= nil then
     iv.info:clear_diff_pin()
   end
+end
+
+function infoview.toggle_auto_diff_pin()
+  if not is_lean_buffer() then return end
+  infoview.open()
+  infoview.get_current_infoview().info:toggle_auto_diff_pin()
 end
 
 function infoview.enable_widgets()

--- a/lua/lean/infoview.lua
+++ b/lua/lean/infoview.lua
@@ -80,6 +80,20 @@ local Info = {}
 ---@field info Info
 local Infoview = {}
 
+local pin_hl_group = "LeanNvimPin"
+vim.highlight.create(pin_hl_group, {
+  cterm = 'underline',
+  ctermbg = '3',
+  gui   = 'underline',
+}, true)
+
+local diff_pin_hl_group = "LeanNvimDiffPin"
+vim.highlight.create(diff_pin_hl_group, {
+  cterm = 'underline',
+  ctermbg = '7',
+  gui   = 'underline',
+}, true)
+
 --- Enables printing of extra debugging information in the infoview.
 function infoview.enable_debug()
   infoview.debug = true
@@ -291,9 +305,9 @@ function Info:add_diff_pin(params)
     self.diff_pin:move(params)
   else                  -- create new diff pin
     self.diff_pin = self.pin
+    self.diff_pin:show_extmark("diff", diff_pin_hl_group)
     self.diff_bufdiv = html.BufDiv:new("lean://info/" .. self.id .. "/diff_pin/" .. self.diff_pin.id,
       self.diff_pin.div, options.mappings)
-    self:maybe_show_pin_extmark()
     self.pin = Pin:new(options.autopause, options.use_widget)
     self.pin:add_parent_info(self)
   end
@@ -487,13 +501,6 @@ function Pin:remove_parent_info(info)
   if vim.tbl_isempty(self.parent_infos) then self:_teardown() end
 end
 
-local pin_hl_group = "LeanNvimPin"
-vim.highlight.create(pin_hl_group, {
-  cterm = 'underline',
-  ctermbg = '3',
-  gui   = 'underline',
-}, true)
-
 --- Update this pin's current position.
 function Pin:set_position_params(params, delay, lean3_opts)
   local old_params = self.position_params
@@ -556,8 +563,8 @@ end
 
 function Pin:toggle_pause() if not self.paused then self:pause() else self:unpause() end end
 
-function Pin:show_extmark(name)
-  self.extmark_hl_group = pin_hl_group
+function Pin:show_extmark(name, hlgroup)
+  self.extmark_hl_group = hlgroup or pin_hl_group
   self.extmark_virt_text = {{"← " .. (name or tostring(self.id)), "Comment"}}
   self:update_extmark()
 end

--- a/lua/lean/infoview.lua
+++ b/lua/lean/infoview.lua
@@ -285,22 +285,19 @@ function Info:add_pin()
   self:render()
 end
 
-function Info:add_diff_pin()
-  local old_bufdiv
-  if self.diff_pin then
-    self.diff_pin:remove_parent_info(self)
-    old_bufdiv = self.diff_bufdiv
+function Info:add_diff_pin(params)
+  if self.diff_pin then -- move existing diff pin
+    self.diff_pin:move(params)
+  else                  -- create new diff pin
+    self.diff_pin = self.pin
+    self.diff_bufdiv = html.BufDiv:new("lean://info/" .. self.id .. "/diff_pin/" .. self.diff_pin.id,
+      self.diff_pin.div, options.mappings)
+    self:maybe_show_pin_extmark()
+    self.pin = Pin:new(options.autopause, options.use_widget)
+    self.pin:add_parent_info(self)
   end
 
-  self.diff_pin = self.pin
-  self.diff_bufdiv = html.BufDiv:new("lean://info/" .. self.id .. "/diff_pin/" .. self.diff_pin.id,
-    self.diff_pin.div, options.mappings)
-  self:maybe_show_pin_extmark()
-  self.pin = Pin:new(options.autopause, options.use_widget)
-  self.pin:add_parent_info(self)
   self:refresh_parents()
-
-  if old_bufdiv then old_bufdiv:buf_close() end
 end
 
 function Info:clear_pins()
@@ -893,9 +890,10 @@ function infoview.add_pin()
 end
 
 function infoview.add_diff_pin()
+  if not is_lean_buffer() then return end
   infoview.open()
-  infoview.get_current_infoview().info:add_diff_pin()
-  infoview.__update()
+  infoview.get_current_infoview().info:set_last_window()
+  infoview.get_current_infoview().info:add_diff_pin(vim.lsp.util.make_position_params())
 end
 
 function infoview.clear_pins()

--- a/lua/lean/infoview.lua
+++ b/lua/lean/infoview.lua
@@ -186,24 +186,29 @@ function Infoview:refresh_diff()
     vim.api.nvim_command("setlocal wrap")
 
     if self.orientation == "vertical" then
-      vim.cmd("rightbelow split")
+      vim.cmd("leftabove " .. self.width .. "vsplit")
+      vim.cmd("vertical resize " .. self.width)
     else
-      vim.cmd("rightbelow vsplit")
+      vim.cmd("leftabove " .. self.height .. "split")
+      vim.cmd("resize " .. self.height)
     end
     self.diff_win = vim.api.nvim_get_current_win()
 
     vim.api.nvim_set_current_win(window_before_split)
   end
 
-  -- turn off diff for any preexisting buffer
-  vim.api.nvim_win_call(self.diff_win, function() vim.api.nvim_command"diffoff" end)
+  if vim.api.nvim_win_get_buf(self.diff_win) ~= diff_bufdiv.buf then
+    -- turn off diff for any preexisting buffer
+    vim.api.nvim_win_call(self.diff_win, function() vim.api.nvim_command"diffoff" end)
+    vim.api.nvim_win_set_buf(self.diff_win, diff_bufdiv.buf)
 
-  vim.api.nvim_win_set_buf(self.diff_win, diff_bufdiv.buf)
-  vim.api.nvim_win_call(self.diff_win, function()
-    vim.api.nvim_command"diffthis"
-    vim.api.nvim_command("setlocal foldmethod=manual")
-    vim.api.nvim_command("setlocal wrap")
-  end)
+    vim.api.nvim_win_call(self.diff_win, function()
+      vim.api.nvim_command"diffthis"
+      vim.api.nvim_command("setlocal filetype=leaninfo")
+      vim.api.nvim_command("set foldmethod=manual")
+      vim.api.nvim_command("setlocal wrap")
+    end)
+  end
 end
 
 --- Close this infoview's diff window.

--- a/lua/lean/infoview.lua
+++ b/lua/lean/infoview.lua
@@ -168,15 +168,15 @@ function Infoview:open()
 
   self:focus_on_current_buffer()
 
-  self:refresh_diff()
+  self:__refresh_diff()
 end
 
 --- Either open or close a diff window for this infoview depending on whether its info has a diff_pin.
-function Infoview:refresh_diff()
+function Infoview:__refresh_diff()
   if not self.is_open then return end
 
   local diff_bufdiv = self.info.diff_bufdiv
-  if not diff_bufdiv then self:close_diff() return end
+  if not diff_bufdiv then self:__close_diff() return end
 
   if not self.diff_win then
     local window_before_split = vim.api.nvim_get_current_win()
@@ -212,7 +212,7 @@ function Infoview:refresh_diff()
 end
 
 --- Close this infoview's diff window.
-function Infoview:close_diff()
+function Infoview:__close_diff()
   if not self.is_open or not self.diff_win then return end
 
   vim.api.nvim_win_call(self.window, function() vim.api.nvim_command"diffoff" end)
@@ -233,7 +233,7 @@ function Infoview:close()
     return
   end
 
-  self:close_diff()
+  self:__close_diff()
 
   set_augroup("LeanInfoviewClose", "", self.info.bufdiv.buf)
   vim.api.nvim_win_close(self.window, true)
@@ -322,7 +322,7 @@ function Info:add_diff_pin(params)
     self.pin:add_parent_info(self)
   end
 
-  self:refresh_parents()
+  self:__refresh_parents()
 end
 
 function Info:clear_pins()
@@ -338,7 +338,7 @@ function Info:clear_diff_pin()
   set_augroup("LeanInfoviewClose", "", self.diff_bufdiv.buf)
   self.diff_pin = nil
   self.diff_bufdiv = nil
-  self:refresh_parents()
+  self:__refresh_parents()
 end
 
 --- Show a pin extmark if it is appropriate based on configuration.
@@ -456,9 +456,9 @@ function Info:_render()
 end
 
 --- Refresh parent infoview diff windows.
-function Info:refresh_parents()
+function Info:__refresh_parents()
   for parent_id, _ in pairs(self.parent_infoviews) do
-    infoview._by_id[parent_id]:refresh_diff()
+    infoview._by_id[parent_id]:__refresh_diff()
   end
 end
 

--- a/lua/lean/infoview.lua
+++ b/lua/lean/infoview.lua
@@ -401,8 +401,13 @@ end
 --- Move the current pin to the specified location.
 function Info:move_pin(params)
   if self.auto_diff_pin and self.pin.position_params then
-    -- update diff pin to previous position
-    self:add_diff_pin(self.pin.position_params)
+    if util.position_params_valid(self.pin.position_params) then
+      -- update diff pin to previous position
+      self:add_diff_pin(self.pin.position_params)
+    else
+      -- if previous position invalid, use current position
+      self:add_diff_pin(params)
+    end
   end
   if params then self.pin:move(params) end
 end

--- a/lua/lean/infoview.lua
+++ b/lua/lean/infoview.lua
@@ -277,11 +277,12 @@ function Info:add_parent_infoview(_infoview)
   self.parent_infoviews[_infoview.id] = true
 end
 
-function Info:add_pin()
+function Info:add_pin(params)
   table.insert(self.pins, self.pin)
   self:maybe_show_pin_extmark()
   self.pin = Pin:new(options.autopause, options.use_widget)
   self.pin:add_parent_info(self)
+  if params then self.pin:move(params) end
   self:render()
 end
 
@@ -884,9 +885,10 @@ function infoview.pin_toggle_pause()
 end
 
 function infoview.add_pin()
+  if not is_lean_buffer() then return end
   infoview.open()
-  infoview.get_current_infoview().info:add_pin()
-  infoview.__update()
+  infoview.get_current_infoview().info:set_last_window()
+  infoview.get_current_infoview().info:add_pin(vim.lsp.util.make_position_params())
 end
 
 function infoview.add_diff_pin()

--- a/lua/lean/init.lua
+++ b/lua/lean/init.lua
@@ -17,6 +17,8 @@ local lean = {
       ["<LocalLeader>p"] = "<Cmd>LeanInfoviewPinTogglePause<CR>";
       ["<LocalLeader>x"] = "<Cmd>LeanInfoviewAddPin<CR>";
       ["<LocalLeader>c"] = "<Cmd>LeanInfoviewClearPins<CR>";
+      ["<LocalLeader>dx"] = "<Cmd>LeanInfoviewAddDiffPin<CR>";
+      ["<LocalLeader>dc"] = "<Cmd>LeanInfoviewClearDiffPin<CR>";
       ["<LocalLeader>w"] = "<Cmd>LeanInfoviewEnableWidgets<CR>";
       ["<LocalLeader>W"] = "<Cmd>LeanInfoviewDisableWidgets<CR>";
       ["<LocalLeader><Tab>"] = "<Cmd>LeanGotoInfoview<CR>";
@@ -60,6 +62,8 @@ function lean.setup(opts)
     command LeanInfoviewPinTogglePause :lua require'lean.infoview'.pin_toggle_pause()
     command LeanInfoviewAddPin :lua require'lean.infoview'.add_pin()
     command LeanInfoviewClearPins :lua require'lean.infoview'.clear_pins()
+    command LeanInfoviewAddDiffPin :lua require'lean.infoview'.add_diff_pin()
+    command LeanInfoviewClearDiffPin :lua require'lean.infoview'.clear_diff_pin()
     command LeanInfoviewEnableWidgets :lua require'lean.infoview'.enable_widgets()
     command LeanInfoviewDisableWidgets :lua require'lean.infoview'.disable_widgets()
     command LeanGotoInfoview :lua require'lean.infoview'.go_to()

--- a/lua/lean/init.lua
+++ b/lua/lean/init.lua
@@ -19,6 +19,7 @@ local lean = {
       ["<LocalLeader>c"] = "<Cmd>LeanInfoviewClearPins<CR>";
       ["<LocalLeader>dx"] = "<Cmd>LeanInfoviewAddDiffPin<CR>";
       ["<LocalLeader>dc"] = "<Cmd>LeanInfoviewClearDiffPin<CR>";
+      ["<LocalLeader>dd"] = "<Cmd>LeanInfoviewToggleAutoDiffPin<CR>";
       ["<LocalLeader>w"] = "<Cmd>LeanInfoviewEnableWidgets<CR>";
       ["<LocalLeader>W"] = "<Cmd>LeanInfoviewDisableWidgets<CR>";
       ["<LocalLeader><Tab>"] = "<Cmd>LeanGotoInfoview<CR>";
@@ -64,6 +65,7 @@ function lean.setup(opts)
     command LeanInfoviewClearPins :lua require'lean.infoview'.clear_pins()
     command LeanInfoviewAddDiffPin :lua require'lean.infoview'.add_diff_pin()
     command LeanInfoviewClearDiffPin :lua require'lean.infoview'.clear_diff_pin()
+    command LeanInfoviewToggleAutoDiffPin :lua require'lean.infoview'.toggle_auto_diff_pin()
     command LeanInfoviewEnableWidgets :lua require'lean.infoview'.enable_widgets()
     command LeanInfoviewDisableWidgets :lua require'lean.infoview'.disable_widgets()
     command LeanGotoInfoview :lua require'lean.infoview'.go_to()

--- a/lua/tests/helpers.lua
+++ b/lua/tests/helpers.lua
@@ -425,7 +425,7 @@ local function opened_info(_, arguments)
 
   assert.is_nil(last_info_ids[this_info.id])
 
-  assert.is_truthy(this_info.bufnr)
+  assert.is_truthy(this_info.bufdiv)
   assert.is_falsy(this_info.prev_buf)
 
   return true
@@ -434,8 +434,8 @@ end
 local function opened_info_kept(_, arguments)
   local this_info = arguments[1]
 
-  assert.is_truthy(this_info.bufnr)
-  assert.are_equal(this_info.bufnr, this_info.prev_buf)
+  assert.is_truthy(this_info.bufdiv)
+  assert.are_equal(this_info.bufdiv.buf, this_info.prev_buf)
 
   return true
 end
@@ -641,7 +641,7 @@ local function infoview_check(state, _)
     end
 
     if check == "infoopened" then
-      vim.list_extend(opened_bufs, {this_info.bufnr})
+      vim.list_extend(opened_bufs, {this_info.bufdiv.buf})
       assert.opened_info_state(this_info)
       assert.is_nil(pin_list[this_info.pin.id])
       pin_list[this_info.pin.id] = "pinopened"
@@ -649,7 +649,7 @@ local function infoview_check(state, _)
       assert.opened_info_kept_state(this_info)
     end
 
-    this_info.prev_buf = this_info.bufnr
+    this_info.prev_buf = this_info.bufdiv.buf
     this_info.prev_check = check
 
     info_ids[id] = true


### PR DESCRIPTION
The way this works is you can place down a "diff pin" which is diff'ed against the current info in a separate window using vim's built-in diff functionality. This makes it much easier to figure out exactly what changed from one state to the next. Demo:

[![asciicast](https://asciinema.org/a/pefTLbP2PlVLZplCVxv25hxRg.svg)](https://asciinema.org/a/pefTLbP2PlVLZplCVxv25hxRg)

Widgets still somewhat work in this diff-mode, but there are a few problems with it, for example positioning of floating windows can be broken if the diff is showing deleted lines above. So in this case, for now you should just clear the diff pin if you're serious about interacting with the infoview.