### PR TITLE
Make automatic mouse events configurable and bring back manual keybindings.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -236,6 +236,10 @@ Full Configuration & Settings Information
       -- Lean 3  (on_attach is as above, your LSP handler)
       lsp3 = { on_attach = on_attach },
 
+      -- mouse_events = true will simulate mouse events in the Lean 3 infoview, this is buggy at the moment
+      -- so you can use the I/i keybindings to manually trigger these
+      lean3 = { mouse_events = false },
+
       -- What filetype should be associated with standalone Lean files?
       -- Can be set to "lean3" if you prefer that default.
       -- Having a leanpkg.toml or lean-toolchain file should always mean

--- a/lua/lean/infoview.lua
+++ b/lua/lean/infoview.lua
@@ -34,13 +34,15 @@ local options = {
     autoopen = true,
     autopause = false,
     indicators = "auto",
-    lean3 = { show_filter = true },
+    lean3 = { show_filter = true, mouse_events = false },
     show_processing = true,
     use_widget = true,
 
     mappings = {
       ["K"] = [[click]],
       ["<CR>"] = [[click]],
+      ["I"] = 'mouse_enter',
+      ["i"] = 'mouse_leave',
       ["<Esc>"] = 'clear_all',
       ["C"] = 'clear_all',
       ["<LocalLeader><Tab>"] = [[goto_last_window]]

--- a/lua/lean/lean3.lua
+++ b/lua/lean/lean3.lua
@@ -210,6 +210,14 @@ function lean3.update_infoview(pin, data_div, bufnr, params, use_widget,
       if result.e then
         for event, handler in pairs(result.e) do
           local div_event = to_event[event]
+          if not options.mouse_events then
+            if div_event == "cursor_enter" then
+              div_event = "mouse_enter"
+            end
+            if div_event == "cursor_leave" then
+              div_event = "mouse_leave"
+            end
+          end
           local clickable_event = div_event == "click" or div_event == "change"
           if clickable_event then element_div.highlightable = true end
           events[div_event] = function(ctx, value)


### PR DESCRIPTION
The implementation from #196 is a bit buggy in that if you're moving around really quickly, highlights can sometimes get stuck. So there are some synchronization issues that need to be worked out. So for now I think we should make it configurable (default off) and bring back the old manual keybindings for `mouse_enter`/`mouse_exit`.