### PR TITLE
Obtain lsp.client object for RPC.

### DIFF
--- a/lua/lean/_util.lua
+++ b/lua/lean/_util.lua
@@ -91,6 +91,12 @@ end
 
 M.a_request = a.wrap(M.request, 4)
 
+function M.client_request(client, method, params, handler)
+  return client.request(method, params, M.mk_handler(handler))
+end
+
+M.client_a_request = a.wrap(M.client_request, 4)
+
 -- FIXME: tick locking is disabled for now
 -- It is really easy to crash the infoview this way if an exception is not handled.
 


### PR DESCRIPTION
This is one commit of #118 which didn't get merged in #123.

Probably fixes #189.