### PR TITLE
Ignore empty path in events.

### DIFF
--- a/lua/lean/html.lua
+++ b/lua/lean/html.lua
@@ -601,6 +601,8 @@ function BufDiv:buf_event(event, path, ...)
 
   path = path or self.path
 
+  if not path then return end
+
   if not self.div:event(path, event, self:buf_make_event_context(), unpack(args)) and self.parent then
     -- bubble up to parent
     return self.parent:buf_event(event, self.parent_path, ...)


### PR DESCRIPTION
I've been running into this error several times today, when scrolling to the end of the infoview:
```
Error detected while processing CursorMoved Autocommands for "<buffer=12>":
E5108: Error executing lua /home/gebner/lean.nvim/lua/lean/html.lua:154: bad argument #1 to 'ipairs' (table expected, got nil)
```

AFAICT there is no reason why the `path` must be initialized in `buf_event`, so let's just ignore events where the path is nil.