### PR TITLE
Fix for UTF16 vs. UTF32 positions.

### DIFF
--- a/lua/lean/_util.lua
+++ b/lua/lean/_util.lua
@@ -236,4 +236,22 @@ end
 
 M.wait_timer = a.wrap(function(timeout, handler) vim.defer_fn(handler, timeout) end, 2)
 
+--- Utility function for getting the encoding of the first LSP client on the given buffer.
+---@param bufnr (number) buffer handle or 0 for current, defaults to current
+---@returns (string) encoding first client if there is one, nil otherwise
+function M._get_offset_encoding(bufnr)
+  local offset_encoding
+
+  for _, client in pairs(vim.lsp.buf_get_clients(bufnr)) do
+    local this_offset_encoding = client.offset_encoding or "utf-16"
+    if not offset_encoding then
+      offset_encoding = this_offset_encoding
+    elseif offset_encoding ~= this_offset_encoding then
+      vim.notify("warning: multiple different client offset_encodings detected for buffer, this is not supported yet", vim.log.levels.WARN)
+    end
+  end
+
+  return offset_encoding
+end
+
 return M

--- a/lua/lean/_util.lua
+++ b/lua/lean/_util.lua
@@ -202,20 +202,36 @@ function M.list_workspace_folders()
   return workspace_folders
 end
 
+---@class UIParams
+---@field filename string
+---@field row number
+---@field col number
+
+--- Checks that the given position parameters are valid given the buffer they correspond to.
+---@param params UIParams @parameters to verify
+---@return boolean
 function M.position_params_valid(params)
-  local bufnr = vim.fn.bufnr(vim.uri_to_fname(params.textDocument.uri))
+  local bufnr = vim.fn.bufnr(params.filename)
   if bufnr == -1 then return false end
 
   local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, true)
 
-  local line = params.position.line + 1
-  local col = params.position.character + 1
+  local line = params.row + 1
+  local col = params.col + 1
 
   if line > #lines then return false end
 
-  if col > vim.fn.strwidth(lines[line]) then return false end
+  if col > #lines[line] then return false end
 
   return true
+end
+
+function M.make_position_params()
+  local buf = vim.api.nvim_win_get_buf(0)
+  local row, col = unpack(vim.api.nvim_win_get_cursor(0))
+  row = row - 1
+
+  return { filename = vim.api.nvim_buf_get_name(buf), row = row, col = col }
 end
 
 M.wait_timer = a.wrap(function(timeout, handler) vim.defer_fn(handler, timeout) end, 2)

--- a/lua/lean/infoview.lua
+++ b/lua/lean/infoview.lua
@@ -676,7 +676,7 @@ function Pin:update_position()
 
   local extmark_pos = vim.api.nvim_buf_get_extmark_by_id(buf, extmark_ns, extmark, {})
 
-  local encoding = vim.lsp.util._get_offset_encoding and vim.lsp.util._get_offset_encoding(buf) or "utf-32"
+  local encoding = util._get_offset_encoding(buf) or "utf-32"
   local use_utf16 = encoding == "utf-16"
   local new_pos = {}
 

--- a/lua/lean/infoview.lua
+++ b/lua/lean/infoview.lua
@@ -59,6 +59,7 @@ local options = {
 ---@field data_div Div
 ---@field div Div
 ---@field ticker table
+---@field __ui_position_params UIParams
 local Pin = {next_id = 1}
 
 --- An individual info.
@@ -379,7 +380,7 @@ function Info:__new_current_pin()
 end
 
 function Info:add_pin()
-  local new_params = vim.deepcopy(self.pin.position_params)
+  local new_params = vim.deepcopy(self.pin.__ui_position_params)
   table.insert(self.pins, self.pin)
   self:maybe_show_pin_extmark(tostring(self.pin.id))
   self:__new_current_pin()
@@ -387,6 +388,7 @@ function Info:add_pin()
   self:render()
 end
 
+---@param params UIParams
 function Info:set_diff_pin(params)
   if not self.diff_pin then
     self.diff_pin = Pin:new(options.autopause, options.use_widget)
@@ -452,13 +454,14 @@ function Info:__render_pins()
       if pin.loading then add_attribute("LOADING", "loading") end
     end
 
-    if not current and pin.position_params then
-      local bufnr = vim.fn.bufnr(vim.uri_to_fname(pin.position_params.textDocument.uri))
+    local params = pin.__ui_position_params
+    if not current and params then
+      local bufnr = vim.fn.bufnr(params.filename)
       local filename
       if bufnr ~= -1 then
         filename = vim.fn.bufname(bufnr)
       else
-        filename = pin.position_params.textDocument.uri
+        filename = params.filename
       end
       if not infoview.debug then
         header_div:insert_div("-- ", "pin-id-header")
@@ -466,7 +469,7 @@ function Info:__render_pins()
         header_div:insert_div(": ", "pin-header-separator")
       end
       local location_text = ("%s at %d:%d"):format(filename,
-        pin.position_params.position.line + 1, pin.position_params.position.character + 1)
+        params.row + 1, params.col + 1)
       header_div:insert_div(location_text, "pin-location")
 
       header_div.highlightable = true
@@ -474,10 +477,9 @@ function Info:__render_pins()
         click = function()
           if self.last_window then
             vim.api.nvim_set_current_win(self.last_window)
-            local uri_bufnr = vim.uri_to_bufnr(pin.position_params.textDocument.uri)
+            local uri_bufnr = vim.fn.bufnr(params.filename)
             vim.api.nvim_set_current_buf(uri_bufnr)
-            vim.api.nvim_win_set_cursor(0,
-              { pin.position_params.position.line + 1, pin.position_params.position.character })
+            vim.api.nvim_win_set_cursor(0, { params.row + 1, params.col })
           end
         end
       }
@@ -517,10 +519,11 @@ end
 
 --- Update the diff pin to use the current pin's positon params if they are valid,
 --- and the provided params if they are not.
+---@param params UIParams
 function Info:__update_auto_diff_pin(params)
-  if self.pin.position_params and util.position_params_valid(self.pin.position_params) then
+  if self.pin.__ui_position_params and util.position_params_valid(self.pin.__ui_position_params) then
     -- update diff pin to previous position
-    self:set_diff_pin(self.pin.position_params)
+    self:set_diff_pin(self.pin.__ui_position_params)
   elseif params then
     -- if previous position invalid, use current position
     self:set_diff_pin(params)
@@ -528,6 +531,7 @@ function Info:__update_auto_diff_pin(params)
 end
 
 --- Move the current pin to the specified location.
+---@param params UIParams
 function Info:move_pin(params)
   if self.auto_diff_pin then self:__update_auto_diff_pin(params) end
   self.pin:move(params)
@@ -604,45 +608,66 @@ function Pin:remove_parent_info(info)
 end
 
 --- Update this pin's current position.
-function Pin:set_position_params(params, delay, lean3_opts)
-  local old_params = self.position_params
-  self.position_params = params
-
-  lean3_opts = vim.tbl_extend("keep", lean3_opts or {}, {changed = not vim.deep_equal(params, old_params)})
-
-  self:update_extmark()
-  self:update(false, delay, nil, lean3_opts)
+---@param params UIParams
+function Pin:set_position_params(params)
+  self:update_extmark(params)
 end
 
 --- Update pin extmark based on position, used when resetting pin position.
-function Pin:update_extmark()
-  local params = self.position_params
+---@param params UIParams
+function Pin:update_extmark(params)
   if not params then return end
 
-  local buf = vim.fn.bufnr(vim.uri_to_fname(params.textDocument.uri))
+  local buf = vim.fn.bufnr(params.filename)
 
   if buf ~= -1 then
-    local line = params.position.line
-    local buf_line = vim.api.nvim_buf_get_lines(buf, line, line + 1, false)[1]
-    local col = buf_line and vim.str_byteindex(buf_line, params.position.character) or 0
-    local end_col = buf_line and ((col < #buf_line) and
-      vim.str_byteindex(buf_line, params.position.character + 1) or col) or 0
+    local line = params.row
+    local col = params.col
 
-    self.extmark = vim.api.nvim_buf_set_extmark(buf, extmark_ns,
-      line, col,
-      {
-        id = self.extmark;
-        end_col = end_col;
-        hl_group = self.extmark_hl_group;
-        virt_text = self.extmark_virt_text;
-        virt_text_pos = "right_align";
-      })
-    self.extmark_buf = buf
+    self:__update_extmark_style(buf, line, col)
+
+    self:update_position()
   end
 end
 
---- Update pin position based on extmark, used when changing text.
-function Pin:update_position(delay, lean3_opts)
+function Pin:__update_extmark_style(buf, line, col)
+  if not buf and not self.extmark then return end
+
+  -- not a brand new extmark
+  if not buf then
+    buf = self.extmark_buf
+    local extmark_pos = vim.api.nvim_buf_get_extmark_by_id(buf, extmark_ns, self.extmark, {})
+    line = extmark_pos[1]
+    col = extmark_pos[2]
+  end
+
+  local buf_line = vim.api.nvim_buf_get_lines(buf, line, line + 1, false)[1]
+  local end_col = 0
+  if buf_line then
+    if col < #buf_line then
+      -- vim.str_utfindex rounds up to the next UTF16 index if in the middle of a UTF8 sequence;
+      -- so convert next byte to UTF16 and back to get UTF8 index of next codepoint
+      local _, next_utf16 = vim.str_utfindex(buf_line, col + 1)
+      end_col = (col < #buf_line) and vim.str_byteindex(buf_line, next_utf16, true)
+    else
+      end_col = col
+    end
+  end
+
+  self.extmark = vim.api.nvim_buf_set_extmark(buf, extmark_ns,
+    line, col,
+    {
+      id = self.extmark;
+      end_col = end_col;
+      hl_group = self.extmark_hl_group;
+      virt_text = self.extmark_virt_text;
+      virt_text_pos = "right_align";
+    })
+  self.extmark_buf = buf
+end
+
+--- Update pin position based on extmark, used directly when changing text, indirectly when setting position.
+function Pin:update_position()
   local extmark = self.extmark
   if not extmark then return end
 
@@ -651,16 +676,24 @@ function Pin:update_position(delay, lean3_opts)
 
   local extmark_pos = vim.api.nvim_buf_get_extmark_by_id(buf, extmark_ns, extmark, {})
 
-  local pos = self.position_params.position
-  local new_pos = vim.deepcopy(pos)
+  local encoding = vim.lsp.util._get_offset_encoding and vim.lsp.util._get_offset_encoding(buf) or "utf-32"
+  local use_utf16 = encoding == "utf-16"
+  local new_pos = {}
 
   new_pos.line = extmark_pos[1]
   local buf_line = vim.api.nvim_buf_get_lines(buf, new_pos.line, new_pos.line + 1, false)[1]
-  new_pos.character = buf_line and vim.str_utfindex(buf_line, extmark_pos[2]) or new_pos.character
+  if buf_line then
+    local utf32, utf16 = vim.str_utfindex(buf_line, extmark_pos[2])
+    new_pos.character = use_utf16 and utf16 or utf32
+  else
+    new_pos.character = 0
+  end
 
-  local new_params = vim.deepcopy(self.position_params)
-  new_params.position = new_pos
-  self:set_position_params(new_params, delay, lean3_opts)
+  local new_params = { textDocument = { uri = vim.uri_from_bufnr(buf) }, position = new_pos }
+  local new_ui_params = { filename = vim.uri_to_fname(vim.uri_from_bufnr(buf)),
+    row = extmark_pos[1], col = extmark_pos[2] }
+  self.__position_params = new_params
+  self.__ui_position_params = new_ui_params
 end
 
 function Pin:toggle_pause() if not self.paused then self:pause() else self:unpause() end end
@@ -672,13 +705,13 @@ function Pin:show_extmark(name, hlgroup)
   else
     self.extmark_virt_text = nil
   end
-  self:update_extmark()
+  self:__update_extmark_style()
 end
 
 function Pin:hide_extmark()
   self.extmark_hl_group = nil
   self.extmark_virt_text = nil
-  self:update_extmark()
+  self:__update_extmark_style()
 end
 
 function Pin:unpause()
@@ -701,9 +734,11 @@ function Pin:pause()
   self.ticker:lock()
 end
 
--- Triggered when manually moving a pin.
+--- Triggered when manually moving a pin.
+---@param params UIParams
 function Pin:move(params)
   self:set_position_params(params)
+  self:update()
 end
 
 function Pin:render_parents()
@@ -753,7 +788,7 @@ end
 Pin.update = a.void(Pin.async_update)
 
 function Pin:_update(force, delay, tick, lean3_opts)
-  if self.position_params and (force or not self.paused) then
+  if self.__position_params and (force or not self.paused) then
     return self:__update(tick, delay, lean3_opts)
   end
 end
@@ -773,7 +808,7 @@ function Pin:__update(tick, delay, lean3_opts)
     util.wait_timer(delay)
   end
 
-  local params = self.position_params
+  local params = self.__position_params
 
   local buf = vim.fn.bufnr(vim.uri_to_fname(params.textDocument.uri))
   if buf == -1 then
@@ -934,14 +969,14 @@ function infoview.__update(id)
 
   if not is_lean_buffer() then return end
   info:set_last_window()
-  pcall(info.move_pin, info, vim.lsp.util.make_position_params())
+  pcall(info.move_pin, info, util.make_position_params())
 end
 
 --- Update pins corresponding to the given URI.
 function infoview.__update_event(uri)
   if infoview.enabled then
     for _, pin in pairs(infoview._pin_by_id) do
-      if pin.position_params and pin.position_params.textDocument.uri == uri then
+      if pin.__position_params and pin.__position_params.textDocument.uri == uri then
         pin:update()
       end
     end
@@ -951,8 +986,11 @@ end
 --- on_lines callback to update pins position according to the given textDocument/didChange parameters.
 function infoview.__update_pin_positions(_, bufnr, _, _, _, _, _, _, _)
   for _, pin in pairs(infoview._pin_by_id) do
-    if pin.position_params and pin.position_params.textDocument.uri == vim.uri_from_bufnr(bufnr) then
-      vim.schedule_wrap(function() pin:update_position(500) end)()
+    if pin.__position_params and pin.__position_params.textDocument.uri == vim.uri_from_bufnr(bufnr) then
+      vim.schedule_wrap(function()
+        pin:update_position()
+        pin:update(false, 500)
+      end)()
     end
   end
 end
@@ -1049,7 +1087,7 @@ function infoview.set_diff_pin()
   if not is_lean_buffer() then return end
   infoview.open()
   infoview.get_current_infoview().info:set_last_window()
-  infoview.get_current_infoview().info:set_diff_pin(vim.lsp.util.make_position_params())
+  infoview.get_current_infoview().info:set_diff_pin(util.make_position_params())
 end
 
 function infoview.clear_pins()

--- a/lua/lean/lean3.lua
+++ b/lua/lean/lean3.lua
@@ -228,7 +228,7 @@ function lean3.update_infoview(pin, data_div, bufnr, params, use_widget,
               kind = event,
               handler = handler,
               args = args,
-              textDocument = pin.position_params.textDocument
+              textDocument = pin.__position_params.textDocument
             }})
             if div_event == "cursor_leave" then
               ctx.self:buf_event("cursor_enter")
@@ -333,8 +333,8 @@ function lean3.update_infoview(pin, data_div, bufnr, params, use_widget,
   -- update all other pins for the same URI so they aren't left with a stale "session"
   if opts and opts.widget_event then
     for _, other_pin in pairs(require"lean.infoview"._pin_by_id) do
-      if other_pin ~= pin and other_pin.position_params and
-        other_pin.position_params.textDocument.uri == pin.position_params.textDocument.uri then
+      if other_pin ~= pin and other_pin.__position_params and
+        other_pin.__position_params.textDocument.uri == pin.__position_params.textDocument.uri then
         other_pin:update()
       end
     end

--- a/lua/lean/lean3.lua
+++ b/lua/lean/lean3.lua
@@ -357,6 +357,7 @@ function lean3.lsp_enable(opts)
       vim.lsp.handlers['textDocument/publishDiagnostics'](...)
     end;
   })
+  opts.offset_encoding = "utf-32"
   require'lspconfig'.lean3ls.setup(opts)
 end
 

--- a/lua/tests/fixtures/example-lean3-project/src/bar/baz.lean
+++ b/lua/tests/fixtures/example-lean3-project/src/bar/baz.lean
@@ -14,3 +14,5 @@ end
 
 def new_test : bool := by
   exact false
+
+def utf_test {𝔽 : Type} : 𝔽 = 𝔽 := rfl

--- a/lua/tests/fixtures/example-lean4-project/Test.lean
+++ b/lua/tests/fixtures/example-lean4-project/Test.lean
@@ -14,3 +14,5 @@ theorem test2 : p ∨ q → q ∨ p := by
 
 def new_test : Bool := by
   exact false
+
+def utf_test {𝔽 : Type} : 𝔽 = 𝔽 := rfl

--- a/lua/tests/helpers.lua
+++ b/lua/tests/helpers.lua
@@ -23,6 +23,7 @@ local default_config = {
     autoopen = false,
     autopause = true,
     show_processing = false,
+    show_no_info_message = true,
     lean3 = { show_filter = false }
   },
   stderr = { enable = false },

--- a/lua/tests/helpers.lua
+++ b/lua/tests/helpers.lua
@@ -714,7 +714,7 @@ local function infoview_check(state, _)
     if check == "pinopened" then
       assert.opened_pin_state(this_pin)
       this_pin.prev_div_text = this_pin.div:to_string()
-      this_pin.prev_position_params = vim.deepcopy(this_pin.position_params)
+      this_pin.prev_position_params = vim.deepcopy(this_pin.__position_params)
       -- assume text and pos kept if unspecified
       if pin_text_list[id] == nil then
         pin_text_list[id] = "pin_text_kept"
@@ -758,13 +758,13 @@ local function infoview_check(state, _)
 
     if pos_check == "pin_pos_changed" then
       check_change(function() return this_pin.prev_position_params end,
-        function() return this_pin.position_params end, true, "position")
+        function() return this_pin.__position_params end, true, "position")
     else
       check_change(function() return this_pin.prev_position_params end,
-        function() return this_pin.position_params end, false, "position")
+        function() return this_pin.__position_params end, false, "position")
     end
 
-    this_pin.prev_position_params = vim.deepcopy(this_pin.position_params)
+    this_pin.prev_position_params = vim.deepcopy(this_pin.__position_params)
     this_pin.prev_pos_check = pos_check
 
     --

--- a/lua/tests/infoview/lsp/pin_spec.lua
+++ b/lua/tests/infoview/lsp/pin_spec.lua
@@ -1,7 +1,7 @@
 local infoview = require('lean.infoview')
 local helpers = require('tests.helpers')
 local fixtures = require('tests.fixtures')
-local position = require('vim.lsp.util').make_position_params
+local position = require('lean._util').make_position_params
 
 helpers.setup {
   infoview = { autoopen = true },

--- a/lua/tests/infoview/lsp/position_spec.lua
+++ b/lua/tests/infoview/lsp/position_spec.lua
@@ -1,7 +1,7 @@
 local infoview = require('lean.infoview')
 local helpers = require('tests.helpers')
 local fixtures = require('tests.fixtures')
-local position = require('vim.lsp.util').make_position_params
+local position = require('lean._util').make_position_params
 
 helpers.setup {
   infoview = { autoopen = true },
@@ -34,8 +34,8 @@ describe('infoview pin', function()
     function(_)
       vim.api.nvim_buf_set_lines(0, 3, 4, true, {"def boop : Nat := 5"})
       assert.pin_pos_kept.infoview()
-      assert.are_equal(2, infoview.get_current_infoview().info.pin.position_params.position.line)
-      assert.are_equal(18, infoview.get_current_infoview().info.pin.position_params.position.character)
+      assert.are_equal(2, infoview.get_current_infoview().info.pin.__position_params.position.line)
+      assert.are_equal(18, infoview.get_current_infoview().info.pin.__position_params.position.character)
     end)
 
     it('when lines added below',
@@ -71,8 +71,8 @@ describe('infoview pin', function()
     function(_)
       vim.api.nvim_buf_set_lines(0, 1, 2, true, {"", ""})
       assert.pin_pos_changed.infoview()
-      assert.are_equal(3, infoview.get_current_infoview().info.pin.position_params.position.line)
-      assert.are_equal(18, infoview.get_current_infoview().info.pin.position_params.position.character)
+      assert.are_equal(3, infoview.get_current_infoview().info.pin.__position_params.position.line)
+      assert.are_equal(18, infoview.get_current_infoview().info.pin.__position_params.position.character)
     end)
 
     it('on change before on same line',
@@ -81,8 +81,8 @@ describe('infoview pin', function()
 
       vim.api.nvim_command("normal! $bbeaa")
       assert.pin_pos_changed.infoview()
-      assert.are_equal(2, infoview.get_current_infoview().info.pin.position_params.position.line)
-      assert.are_equal(19, infoview.get_current_infoview().info.pin.position_params.position.character)
+      assert.are_equal(2, infoview.get_current_infoview().info.pin.__position_params.position.line)
+      assert.are_equal(19, infoview.get_current_infoview().info.pin.__position_params.position.character)
     end)
   end)
 end)

--- a/lua/tests/infoview/lsp/run_spec.lua
+++ b/lua/tests/infoview/lsp/run_spec.lua
@@ -1,7 +1,7 @@
 local infoview = require('lean.infoview')
 local helpers = require('tests.helpers')
 local fixtures = require('tests.fixtures')
-local position = require('vim.lsp.util').make_position_params
+local position = require('lean._util').make_position_params
 
 helpers.setup {
   infoview = { autoopen = true },
@@ -45,6 +45,31 @@ describe('infoview', function()
         assert.pin_pos_changed.pin_text_changed.infoview()
         assert.has_all(infoview.get_current_infoview().info.pin.div:to_string(), {"1 goal\n⊢ Nat"})
       end)
+
+      it('shows state following multi-index UTF-16 character',
+      function(_)
+        vim.api.nvim_win_set_cursor(0, {18, 44})
+        infoview.get_current_infoview().info.pin:set_position_params(position())
+        infoview.get_current_infoview().info.pin:update(true)
+        assert.pin_pos_changed.pin_text_changed.infoview()
+        assert.has_all(infoview.get_current_infoview().info.pin.div:to_string(), {"𝔽 : Type", "⊢ 𝔽 = 𝔽"})
+
+        vim.api.nvim_win_set_cursor(0, {18, 45})
+        infoview.get_current_infoview().info.pin:set_position_params(position())
+        infoview.get_current_infoview().info.pin:update(true)
+        assert.pin_pos_changed.pin_text_kept.infoview()
+
+        vim.api.nvim_win_set_cursor(0, {18, 46})
+        infoview.get_current_infoview().info.pin:set_position_params(position())
+        infoview.get_current_infoview().info.pin:update(true)
+        assert.pin_pos_changed.pin_text_kept.infoview()
+
+        vim.api.nvim_win_set_cursor(0, {18, 43})
+        infoview.get_current_infoview().info.pin:set_position_params(position())
+        infoview.get_current_infoview().info.pin:update(true)
+        assert.pin_pos_changed.pin_text_changed.infoview()
+        assert.has_all(infoview.get_current_infoview().info.pin.div:to_string(), {"No info."})
+      end)
     end
   end)
 
@@ -83,6 +108,31 @@ describe('infoview', function()
       assert.pin_pos_changed.pin_text_changed.infoview()
       assert.equal(infoview.get_current_infoview().info.pin.div:to_string(),
       '▶ expected type:\n⊢ Type 1')
+    end)
+
+    it('shows state following multi-index UTF-16 character',
+    function(_)
+      vim.api.nvim_win_set_cursor(0, {18, 44})
+      infoview.get_current_infoview().info.pin:set_position_params(position())
+      infoview.get_current_infoview().info.pin:update(true)
+      assert.pin_pos_changed.pin_text_changed.infoview()
+      assert.has_all(infoview.get_current_infoview().info.pin.div:to_string(), {"𝔽 : Type", "⊢ 𝔽 = 𝔽"})
+
+      vim.api.nvim_win_set_cursor(0, {18, 45})
+      infoview.get_current_infoview().info.pin:set_position_params(position())
+      infoview.get_current_infoview().info.pin:update(true)
+      assert.pin_pos_changed.pin_text_kept.infoview()
+
+      vim.api.nvim_win_set_cursor(0, {18, 46})
+      infoview.get_current_infoview().info.pin:set_position_params(position())
+      infoview.get_current_infoview().info.pin:update(true)
+      assert.pin_pos_changed.pin_text_kept.infoview()
+
+      vim.api.nvim_win_set_cursor(0, {18, 43})
+      infoview.get_current_infoview().info.pin:set_position_params(position())
+      infoview.get_current_infoview().info.pin:update(true)
+      assert.pin_pos_changed.pin_text_changed.infoview()
+      assert.has_all(infoview.get_current_infoview().info.pin.div:to_string(), {"No info."})
     end)
   end)
 


### PR DESCRIPTION
Closes #206 following neovim/neovim#16382, though should be backwards-compatible. Will add some proper tests soon.