### PR TITLE
Make current pin unfocusable.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -176,6 +176,8 @@ In Lean Files
 +------------------------+----------------------------------------------------+
 | ``<LocalLeader>dt``    | toggle auto diff pin mode without clearing diff pin|
 +------------------------+----------------------------------------------------+
+| ``<LocalLeader>f``     | toggle focus on current pin                        |
++------------------------+----------------------------------------------------+
 | ``<LocalLeader>s``     | insert a ``sorry`` for each open goal              |
 +------------------------+----------------------------------------------------+
 | ``<LocalLeader>t``     | replace a "try this:" suggestion under the cursor  |

--- a/lua/lean/infoview.lua
+++ b/lua/lean/infoview.lua
@@ -1153,6 +1153,19 @@ function infoview.toggle_focus_curr_pin()
   end
 end
 
+function infoview.goto_curr_pin()
+  if not is_lean_buffer() then return end
+
+  local iv = infoview.get_current_infoview()
+  if iv ~= nil then
+    local curr_pin = iv.info.pin
+    local params = curr_pin.__ui_position_params
+    local uri_bufnr = vim.fn.bufnr(params.filename)
+    vim.api.nvim_set_current_buf(uri_bufnr)
+    vim.api.nvim_win_set_cursor(0, { params.row + 1, params.col })
+  end
+end
+
 function infoview.enable_widgets()
   local iv = infoview.get_current_infoview()
   if iv ~= nil then iv.info.pin:set_widget(true) end

--- a/lua/lean/init.lua
+++ b/lua/lean/init.lua
@@ -22,6 +22,7 @@ local lean = {
       ["<LocalLeader>dd"] = "<Cmd>LeanInfoviewToggleAutoDiffPin<CR>";
       ["<LocalLeader>dt"] = "<Cmd>LeanInfoviewToggleNoClearAutoDiffPin<CR>";
       ["<LocalLeader>f"] = "<Cmd>LeanInfoviewToggleFocusCurrPin<CR>";
+      ["<LocalLeader>F"] = "<Cmd>LeanInfoviewGotoCurrPin<CR>";
       ["<LocalLeader>w"] = "<Cmd>LeanInfoviewEnableWidgets<CR>";
       ["<LocalLeader>W"] = "<Cmd>LeanInfoviewDisableWidgets<CR>";
       ["<LocalLeader><Tab>"] = "<Cmd>LeanGotoInfoview<CR>";
@@ -75,6 +76,7 @@ function lean.setup(opts)
     command LeanInfoviewToggleAutoDiffPin :lua require'lean.infoview'.toggle_auto_diff_pin(true)
     command LeanInfoviewToggleNoClearAutoDiffPin :lua require'lean.infoview'.toggle_auto_diff_pin(false)
     command LeanInfoviewToggleFocusCurrPin :lua require'lean.infoview'.toggle_focus_curr_pin()
+    command LeanInfoviewGotoCurrPin :lua require'lean.infoview'.goto_curr_pin()
     command LeanInfoviewEnableWidgets :lua require'lean.infoview'.enable_widgets()
     command LeanInfoviewDisableWidgets :lua require'lean.infoview'.disable_widgets()
     command LeanGotoInfoview :lua require'lean.infoview'.go_to()

--- a/lua/lean/init.lua
+++ b/lua/lean/init.lua
@@ -21,6 +21,7 @@ local lean = {
       ["<LocalLeader>dc"] = "<Cmd>LeanInfoviewClearDiffPin<CR>";
       ["<LocalLeader>dd"] = "<Cmd>LeanInfoviewToggleAutoDiffPin<CR>";
       ["<LocalLeader>dt"] = "<Cmd>LeanInfoviewToggleNoClearAutoDiffPin<CR>";
+      ["<LocalLeader>f"] = "<Cmd>LeanInfoviewToggleFocusCurrPin<CR>";
       ["<LocalLeader>w"] = "<Cmd>LeanInfoviewEnableWidgets<CR>";
       ["<LocalLeader>W"] = "<Cmd>LeanInfoviewDisableWidgets<CR>";
       ["<LocalLeader><Tab>"] = "<Cmd>LeanGotoInfoview<CR>";
@@ -73,6 +74,7 @@ function lean.setup(opts)
     command LeanInfoviewClearDiffPin :lua require'lean.infoview'.clear_diff_pin()
     command LeanInfoviewToggleAutoDiffPin :lua require'lean.infoview'.toggle_auto_diff_pin(true)
     command LeanInfoviewToggleNoClearAutoDiffPin :lua require'lean.infoview'.toggle_auto_diff_pin(false)
+    command LeanInfoviewToggleFocusCurrPin :lua require'lean.infoview'.toggle_focus_curr_pin()
     command LeanInfoviewEnableWidgets :lua require'lean.infoview'.enable_widgets()
     command LeanInfoviewDisableWidgets :lua require'lean.infoview'.disable_widgets()
     command LeanGotoInfoview :lua require'lean.infoview'.go_to()


### PR DESCRIPTION
The use case I have in mind is being able to "unfocus" the current pin so you can move around in the source, do hover requests etc. without the info text changing. We could emulate this before by pausing the current pin, but this seems much more intentional, and also gives you an extmark and interactive info.