### PR TITLE
Get rid of `lean3_opts` in infoview.

### DIFF
--- a/lua/lean/infoview.lua
+++ b/lua/lean/infoview.lua
@@ -704,7 +704,7 @@ function Pin:__finished_loading()
   return true
 end
 
-function Pin:async_update(force, _, lean3_opts)
+function Pin:async_update(force, lean3_opts)
   if not force and self.paused then return end
 
   local tick = self.__ticker:lock()

--- a/lua/lean/infoview.lua
+++ b/lua/lean/infoview.lua
@@ -721,113 +721,109 @@ end
 
 Pin.update = a.void(Pin.async_update)
 
---- async function to update this pin's contents given the current position.
-function Pin:__update(tick)
-  self:__started_loading()
-  local blocks = {} ---@type Element[]
-  local new_data_element = Element:new{ name = "pin-data" }
-
+---@param tick Tick
+---@return Element?
+function Pin:__mk_data_elem(tick)
   local params = self.__position_params
+  local line = params.position.line
+
+  ::retry::
 
   local buf = vim.fn.bufnr(vim.uri_to_fname(params.textDocument.uri))
   if buf == -1 then
     error("No corresponding buffer found for update.")
-    return false
   end
 
-  --- TODO if changes are currently being debounced for this buffer, add debounce timer delay
-  do
-    local line = params.position.line
-
-    if require"lean.progress".is_processing_at(params) then
-      if options.show_processing then
-        new_data_element:add_child(
-          Element:new{
-            text = "Processing file...",
-            name = "processing-msg"
-          }
-        )
-      end
-      goto finish
+  if require"lean.progress".is_processing_at(params) then
+    if options.show_processing then
+      return Element:new{
+        text = "Processing file...",
+        name = "processing-msg"
+      }
     end
-
-    if vim.api.nvim_buf_get_option(buf, "ft") == "lean3" then
-      new_data_element:add_child(
-        lean3.render_pin(self, buf, params, self.__use_widgets, options.lean3))
-      goto finish
-    end
-
-    local sess = rpc.open(buf, params)
-    if not tick:check() then return true end
-
-    local goal_element
-    if self.__use_widgets then
-      local goal, err = sess:getInteractiveGoals(params)
-      if not tick:check() then return true end
-      if err and err.code == protocol.ErrorCodes.ContentModified then
-        return self:__update(tick)
-      end
-      if not err then
-        goal_element = components.interactive_goals(goal, sess)
-      end
-    end
-
-    if not goal_element then
-      local err, goal = leanlsp.plain_goal(params, buf)
-      if not tick:check() then return true end
-      if err and err.code == protocol.ErrorCodes.ContentModified then
-        return self:__update(tick)
-      end
-      goal_element = components.goal(goal)
-    end
-
-    local term_goal_element
-    if self.__use_widgets then
-      local term_goal, err = sess:getInteractiveTermGoal(params)
-      if not tick:check() then return true end
-      if err and err.code == protocol.ErrorCodes.ContentModified then
-        return self:__update(tick)
-      end
-      if not err then
-        term_goal_element = components.interactive_term_goal(term_goal, sess)
-      end
-    end
-
-    if not term_goal_element then
-      local err, term_goal = leanlsp.plain_term_goal(params, buf)
-      if not tick:check() then return true end
-      if err and err.code == protocol.ErrorCodes.ContentModified then
-        return self:__update(tick)
-      end
-      term_goal_element = components.term_goal(term_goal)
-    end
-
-    vim.list_extend(blocks, goal_element)
-    vim.list_extend(blocks, term_goal_element)
-    if options.show_no_info_message and #goal_element + #term_goal_element == 0 then
-      table.insert(blocks, Element:new{ text = "No info.", name = "no-tactic-term" })
-    end
-
-    local diagnostics_element
-    if self.__use_widgets then
-      local diags, err = sess:getInteractiveDiagnostics({ start = line, ['end'] = line + 1 })
-      if not tick:check() then return true end
-      if err and err.code == protocol.ErrorCodes.ContentModified then
-        return self:__update(tick)
-      end
-      if not err then
-        diagnostics_element = components.interactive_diagnostics(diags, line, sess)
-      end
-    end
-
-    vim.list_extend(blocks, diagnostics_element or components.diagnostics(buf, line))
-
-    new_data_element:add_child(Element:concat(blocks, '\n\n'))
-
-    if not tick:check() then return true end
+    return Element:new()
   end
 
-  ::finish::
+  if vim.api.nvim_buf_get_option(buf, "ft") == "lean3" then
+    return lean3.render_pin(self, buf, params, self.__use_widgets, options.lean3)
+  end
+
+  local sess = rpc.open(buf, params)
+  if not tick:check() then return end
+
+  local goal_element
+  if self.__use_widgets then
+    local goal, err = sess:getInteractiveGoals(params)
+    if not tick:check() then return end
+    if err and err.code == protocol.ErrorCodes.ContentModified then
+      goto retry
+    end
+    if not err then
+      goal_element = components.interactive_goals(goal, sess)
+    end
+  end
+
+  if not goal_element then
+    local err, goal = leanlsp.plain_goal(params, buf)
+    if not tick:check() then return end
+    if err and err.code == protocol.ErrorCodes.ContentModified then
+      goto retry
+    end
+    goal_element = components.goal(goal)
+  end
+
+  local term_goal_element
+  if self.__use_widgets then
+    local term_goal, err = sess:getInteractiveTermGoal(params)
+    if not tick:check() then return end
+    if err and err.code == protocol.ErrorCodes.ContentModified then
+      goto retry
+    end
+    if not err then
+      term_goal_element = components.interactive_term_goal(term_goal, sess)
+    end
+  end
+
+  if not term_goal_element then
+    local err, term_goal = leanlsp.plain_term_goal(params, buf)
+    if not tick:check() then return end
+    if err and err.code == protocol.ErrorCodes.ContentModified then
+      goto retry
+    end
+    term_goal_element = components.term_goal(term_goal)
+  end
+
+  local blocks = {}
+  vim.list_extend(blocks, goal_element)
+  vim.list_extend(blocks, term_goal_element)
+  if options.show_no_info_message and #goal_element + #term_goal_element == 0 then
+    table.insert(blocks, Element:new{ text = "No info.", name = "no-tactic-term" })
+  end
+
+  local diagnostics_element
+  if self.__use_widgets then
+    local diags, err = sess:getInteractiveDiagnostics({ start = line, ['end'] = line + 1 })
+    if not tick:check() then return end
+    if err and err.code == protocol.ErrorCodes.ContentModified then
+      goto retry
+    end
+    if not err then
+      diagnostics_element = components.interactive_diagnostics(diags, line, sess)
+    end
+  end
+
+  vim.list_extend(blocks, diagnostics_element or components.diagnostics(buf, line))
+
+  return Element:concat(blocks, '\n\n')
+end
+
+--- async function to update this pin's contents given the current position.
+function Pin:__update(tick)
+  self:__started_loading()
+
+  local new_data_element = self:__mk_data_elem(tick)
+  if not new_data_element or not tick:check() then return end
+
   new_data_element.events.clear_all = function(ctx) ---@param ctx ElementEventContext
     local last_window = ctx.self.last_win
     new_data_element:find(function (element) ---@param element Element
@@ -835,8 +831,8 @@ function Pin:__update(tick)
     end)
     pcall(vim.api.nvim_set_current_win, last_window)
   end
+
   self.__data_element = new_data_element
-  return true
 end
 
 --- Close all open infoviews (across all tabs).

--- a/lua/lean/infoview.lua
+++ b/lua/lean/infoview.lua
@@ -53,7 +53,7 @@ local options = {
 ---@field private __extmark_buf number
 ---@field private __extmark_hl_group string
 ---@field private __extmark_virt_text table
----@field private __ticker table
+---@field private __ticker Ticker
 ---@field private __info Info
 ---@field private __ui_position_params UIParams
 ---@field private __use_widgets boolean

--- a/lua/lean/lean3.lua
+++ b/lua/lean/lean3.lua
@@ -38,6 +38,218 @@ local to_event = {
   ["onChange"] = "change";
 }
 
+local function parse_children(children, options)
+  local prev_element
+  local this_element = Element:new{ name = "children" }
+  for _, child in pairs(children) do
+    local last_hard_stop = false
+    if prev_element then
+      local prev_element_string = prev_element:to_string()
+      if #prev_element_string > 0 then
+        local last_byte_idx = 0
+        if #prev_element_string > 0 then
+          last_byte_idx = vim.str_byteindex(prev_element_string, vim.fn.strchars(prev_element_string) - 1) + 1
+        end
+
+        local last_char = prev_element_string:sub(last_byte_idx, #prev_element_string)
+        if last_char ~= " "
+          and last_char ~= "\n"
+          and last_char ~= "("
+          and last_char ~= "["
+          and last_char ~= "{"
+          and last_char ~= "@"
+          and last_char ~= "↑"
+          and last_char ~= "⇑"
+          and last_char ~= "↥"
+          and last_char ~= "¬"
+          then
+          last_hard_stop = true
+        end
+      end
+    end
+
+    local new_element = lean3.parse_widget(child, options)
+    local new_element_string = new_element:to_string()
+    if #new_element_string == 0 then goto continue end
+
+    local this_hard_start = false
+    if #new_element_string > 0 then
+      local first_char = new_element_string:sub(1, 1)
+      if first_char ~= " "
+        and first_char ~= "\n"
+        and first_char ~= ")"
+        and first_char ~= "]"
+        and first_char ~= "}"
+        and first_char ~= ","
+        and first_char ~= "."
+        then
+        this_hard_start = true
+      end
+    end
+
+    if last_hard_stop and this_hard_start then
+      this_element:add_child(Element:new{ text = " ", name = "separator" })
+    end
+
+    this_element:add_child(new_element)
+
+    prev_element = new_element
+
+    ::continue::
+  end
+  return this_element
+end
+
+local function parse_select(children, select_element, current_value, options)
+  local no_filter_element, no_filter_val, current_text
+  local this_element = Element:new{ name = "select-children" }
+  for child_i, child in pairs(children) do
+    local new_element = lean3.parse_widget(child, options)
+    new_element.events.click = function(ctx)
+      return select_element.events.change(ctx, child.a.value)
+    end
+    new_element.highlightable = true
+    this_element:add_child(new_element)
+    if child_i ~= #children then
+      this_element:add_child(Element:new{ text = "\n", name = 'select-separator' })
+    end
+
+    if child.c[1] == "no filter" then
+      no_filter_element = new_element
+      no_filter_val = child.a.value
+    end
+
+    if child.a.value == current_value then
+      current_text = child.c[1]
+    end
+  end
+  return this_element, no_filter_element, no_filter_val, current_text
+end
+
+function lean3.parse_widget(result, options)
+  if type(result) == "string" then
+    result = result:gsub('^%s*(.-)%s$', '%1')
+    return Element:new{ text = result, name = 'widget-element-string' }
+  elseif is_widget_element(result) then
+    local tag = result.t
+    local children = result.c
+    local attributes = result.a
+    local class_name = attributes and attributes.className
+    local tooltip = result.tt
+    local events = {}
+    local hlgroup
+
+    hlgroup = class_to_hlgroup[class_name]
+    if tag == "button" then hlgroup = hlgroup or "leanInfoButton" end
+
+    local element = Element:new {
+      name = 'element',
+      hlgroup = hlgroup,
+      events = events,
+    }
+
+    if class_name == "goal-goals" then
+      element:add_child(Element:new{ text = '▶ ', name = 'goal-prefix' })
+    end
+
+    -- close tooltip button
+    if tag == "button" and result.c and result.c[1] == "x" or result.c[1] == "×" then
+      element.events.clear = function()
+        element.events["click"]()
+      end
+    end
+
+    if result.e then
+      for event, handler in pairs(result.e) do
+        local element_event = to_event[event]
+        if not options.mouse_events then
+          if element_event == "cursor_enter" then
+            element_event = "mouse_enter"
+          end
+          if element_event == "cursor_leave" then
+            element_event = "mouse_leave"
+          end
+        end
+        local clickable_event = element_event == "click" or element_event == "change"
+        if clickable_event then element.highlightable = true end
+        events[element_event] = function(ctx, value)
+          local args = type(value) == 'string' and { type = 'string', value = value }
+            or { type = 'unit' }
+          options.send_widget_event{
+            kind = event,
+            handler = handler,
+            args = args,
+          }
+          if element_event == "cursor_leave" then
+            ctx.self:buf_event("cursor_enter")
+          end
+        end
+      end
+    end
+
+    if tag == "hr" then
+      element:add_child(
+        Element:new{
+          text = "|",
+          name = "rule",
+          hlgroup = "leanInfoFieldSep",
+        }
+      )
+    end
+
+    if options.show_filter and tag == "select" then
+      local select_children_element, no_filter_element, no_filter_val, current_text =
+        parse_select(children, element, attributes.value, options)
+      if no_filter_val and no_filter_val ~= attributes.value then
+        element.events.clear = function()
+          no_filter_element.events.click()
+          return true
+        end
+      end
+      local select_menu_element = Element:new{
+        text = current_text .. "\n",
+        name = "current-select"
+      }
+      element:add_child(select_menu_element)
+      select_menu_element:add_tooltip(select_children_element)
+    elseif tag == 'ul' then
+      for i, child in ipairs(children) do
+        if i > 2 and child.a and child.a.className == 'lh-copy mt2' then
+          element:add_child(Element:new{ text = '\n\n', name = 'goal-separator' })
+        elseif i > 1 then
+          element:add_child(Element:new{ text = '\n', name = 'list-separator' })
+        end
+        element:add_child(lean3.parse_widget(child, options))
+      end
+    else
+      element:add_child(parse_children(children, options))
+    end
+
+    if tooltip then
+      element:add_tooltip(lean3.parse_widget(tooltip, options))
+    end
+
+    local debug_tags = false
+    if debug_tags then
+      element = Element:new{
+        name = "debug-tags",
+        children = {
+          Element:new{ text = "<" .. tag ..
+              " attributes(" .. vim.inspect(attributes) .. ")" ..
+              " events(" .. vim.inspect(result.e) .. ")" ..
+            ">" },
+          element,
+          Element:new{ text = "</" .. tag .. ">" },
+        },
+      }
+    end
+
+    return element
+  else
+    return parse_children(result.c, options)
+  end
+end
+
 function lean3.update_infoview(
   pin,
   data_element,
@@ -53,236 +265,6 @@ function lean3.update_infoview(
   if not client then return end
 
   local parent_element = Element:new{ name = "lean-3-widget" }
-  local widget
-
-  local list_first
-  local goal_first = true
-
-  local function parse_widget(result)
-    local element = Element:new()
-    local function parse_children(children)
-      local prev_element
-      local this_element = Element:new{ name = "children" }
-      for _, child in pairs(children) do
-        local last_hard_stop = false
-        if prev_element then
-          local prev_element_string = prev_element:to_string()
-          if #prev_element_string > 0 then
-            local last_byte_idx = 0
-            if #prev_element_string > 0 then
-              last_byte_idx = vim.str_byteindex(prev_element_string, vim.fn.strchars(prev_element_string) - 1) + 1
-            end
-
-            local last_char = prev_element_string:sub(last_byte_idx, #prev_element_string)
-            if last_char ~= " "
-              and last_char ~= "\n"
-              and last_char ~= "("
-              and last_char ~= "["
-              and last_char ~= "{"
-              and last_char ~= "@"
-              and last_char ~= "↑"
-              and last_char ~= "⇑"
-              and last_char ~= "↥"
-              and last_char ~= "¬"
-              then
-              last_hard_stop = true
-            end
-          end
-        end
-
-        local new_element = parse_widget(child)
-        local new_element_string = new_element:to_string()
-        if #new_element_string == 0 then goto continue end
-
-        local this_hard_start = false
-        if #new_element_string > 0 then
-          local first_char = new_element_string:sub(1, 1)
-          if first_char ~= " "
-            and first_char ~= "\n"
-            and first_char ~= ")"
-            and first_char ~= "]"
-            and first_char ~= "}"
-            and first_char ~= ","
-            and first_char ~= "."
-            then
-            this_hard_start = true
-          end
-        end
-
-        if last_hard_stop and this_hard_start then
-          this_element:add_child(Element:new{ text = " ", name = "separator" })
-        end
-
-        this_element:add_child(new_element)
-
-        prev_element = new_element
-
-        ::continue::
-      end
-      return this_element
-    end
-
-    local function parse_select(children, select_element, current_value)
-      local no_filter_element, no_filter_val, current_text
-      local this_element = Element:new{ name = "select-children" }
-      for child_i, child in pairs(children) do
-        local new_element = parse_widget(child)
-        new_element.events.click = function(ctx)
-          return select_element.events.change(ctx, child.a.value)
-        end
-        new_element.highlightable = true
-        this_element:add_child(new_element)
-        if child_i ~= #children then
-          this_element:add_child(Element:new{ text = "\n", name = 'select-separator' })
-        end
-
-        if child.c[1] == "no filter" then
-          no_filter_element = new_element
-          no_filter_val = child.a.value
-        end
-
-        if child.a.value == current_value then
-          current_text = child.c[1]
-        end
-      end
-      return this_element, no_filter_element, no_filter_val, current_text
-    end
-
-    if type(result) == "string" then
-      result = result:gsub('^%s*(.-)%s$', '%1')
-
-      element:add_child(Element:new{ text = result, name = 'widget-element-string' })
-
-      return element
-    elseif is_widget_element(result) then
-      local tag = result.t
-      local children = result.c
-      local attributes = result.a
-      local class_name = attributes and attributes.className
-      local tooltip = result.tt
-      local events = {}
-      local hlgroup
-
-      if tag == "ul" then
-        list_first = true
-      end
-
-      if tag == "li" then
-        if list_first then
-          list_first = false
-        else
-          element:add_child(Element:new{ text = '\n', name = 'list-separator' })
-        end
-      end
-
-      hlgroup = class_to_hlgroup[class_name]
-      if tag == "button" then hlgroup = hlgroup or "leanInfoButton" end
-
-      if class_name == "goal-goals" then
-        element:add_child(Element:new{ text = '▶ ', name = 'goal-prefix' })
-        goal_first = false
-      end
-      if class_name == "lh-copy mt2" and not goal_first then
-        element:add_child(Element:new{ text = '\n', name = 'goal-separator' })
-      end
-
-      local debug_tags = false
-      if debug_tags then
-        element:add_child(
-          Element:new{
-            text = "<" .. tag ..
-              " attributes(" .. vim.inspect(attributes) .. ")" ..
-              " events(" .. vim.inspect(result.e) .. ")" ..
-            ">",
-            name = "element"
-          }
-        )
-      end
-      local element_element = Element:new{
-        name = "element",
-        hlgroup = hlgroup,
-        events = events
-      }
-      element:add_child(element_element)
-
-      -- close tooltip button
-      if tag == "button" and result.c and result.c[1] == "x" or result.c[1] == "×" then
-        element_element.events.clear = function()
-          element_element.events["click"]()
-        end
-      end
-
-      if result.e then
-        for event, handler in pairs(result.e) do
-          local element_event = to_event[event]
-          if not options.mouse_events then
-            if element_event == "cursor_enter" then
-              element_event = "mouse_enter"
-            end
-            if element_event == "cursor_leave" then
-              element_event = "mouse_leave"
-            end
-          end
-          local clickable_event = element_event == "click" or element_event == "change"
-          if clickable_event then element_element.highlightable = true end
-          events[element_event] = function(ctx, value)
-            local args = type(value) == 'string' and { type = 'string', value = value }
-              or { type = 'unit' }
-            pin:async_update(false, ctx, {widget_event = {
-              widget = widget,
-              kind = event,
-              handler = handler,
-              args = args,
-              textDocument = pin.__position_params.textDocument
-            }})
-            if element_event == "cursor_leave" then
-              ctx.self:buf_event("cursor_enter")
-            end
-          end
-        end
-      end
-
-      if tag == "hr" then
-        element_element:add_child(
-          Element:new{
-            text = "|",
-            name = "rule",
-            hlgroup = "leanInfoFieldSep",
-          }
-        )
-      end
-
-      if options.show_filter and tag == "select" then
-        local select_children_element, no_filter_element, no_filter_val, current_text =
-          parse_select(children, element_element, attributes.value)
-        if no_filter_val and no_filter_val ~= attributes.value then
-          element_element.events.clear = function()
-            no_filter_element.events.click()
-            return true
-          end
-        end
-        local select_menu_element = Element:new{
-          text = current_text .. "\n",
-          name = "current-select"
-        }
-        element_element:add_child(select_menu_element)
-        select_menu_element:add_tooltip(select_children_element)
-      else
-        element_element:add_child(parse_children(children))
-      end
-
-      if tooltip then
-        element_element:add_tooltip(parse_widget(tooltip))
-      end
-      if debug_tags then
-        element:add_child(Element:new{ text = "</" .. tag .. ">", name = "element" })
-      end
-      return element
-    else
-      element:add_child(parse_children(result.c))
-      return element
-    end
-  end
 
   params = vim.deepcopy(params)
   local state_element --- @type Element?
@@ -325,8 +307,16 @@ function lean3.update_infoview(
         end
       end
 
-      widget = result.widget
-      state_element = parse_widget(result.widget.html)
+      local widget = result.widget
+      state_element = lean3.parse_widget(result.widget.html, {
+        mouse_events = options.mouse_events,
+        show_filter = options.show_filter,
+        send_widget_event = function(ev)
+          ev.textDocument = pin.__position_params.textDocument
+          ev.widget = widget
+          pin:async_update(false, { widget_event = ev })
+        end,
+      })
     end
   end
 

--- a/lua/lean/widgets.lua
+++ b/lua/lean/widgets.lua
@@ -671,11 +671,16 @@ function BufRenderer:get_deepest_tooltip()
   return self
 end
 
-function BufRenderer:hop_to()
+function BufRenderer:get_root_ancestor()
   while self.parent do
     self = self.parent
   end
-  self:hop(function(element) return element.highlightable end, require"hop.hint_util".callbacks.win_goto)
+  return self
+end
+
+function BufRenderer:hop_to()
+  self:get_root_ancestor()
+      :hop(function(element) return element.highlightable end, require"hop.hint_util".callbacks.win_goto)
 end
 
 function BufRenderer:hop(filter_fn, callback_fn)

--- a/lua/tests/infoview/contents_spec.lua
+++ b/lua/tests/infoview/contents_spec.lua
@@ -349,7 +349,6 @@ describe('infoview content (auto-)update', function()
         assert.infoview_contents.are[[
           filter: no filter
           ▶ 1 goal
-
           p q : Prop
           ⊢ p ∨ q → q ∨ p
         ]]
@@ -361,7 +360,6 @@ describe('infoview content (auto-)update', function()
         assert.infoview_contents.are[[
           filter: no filter
           ▶ 2 goals
-
           case nat.zero
           ⊢ 0 = 0
 


### PR DESCRIPTION
The main goal of this PR is to remove the circular infoview <-> Lean 3 widgets dependency, where Lean 3 widgets send events to the server by updating the infoview with a special `lean3_opts` argument.  This made any changes to the updating logic annoying, because you always had to keep track of this special code path for Lean 3.

There's now a total of six lines in `infoview.lua` for Lean 3 support.