### PR TITLE
Include the specific TComment config.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,9 +33,10 @@ Install via your favorite plugin manager. E.g., with
 
     " Optional Dependencies:
 
-    Plug 'hrsh7th/nvim-cmp'  " For LSP completion
-    Plug 'hrsh7th/vim-vsnip'   " For snippets
+    Plug 'hrsh7th/nvim-cmp'        " For LSP completion
+    Plug 'hrsh7th/vim-vsnip'       " For snippets
     Plug 'andrewradev/switch.vim'  " For Lean switch support
+    Plug 'tomtom/tcomment_vim'     " For commenting motions
 
 ``lean.nvim`` already includes syntax highlighting and Lean filetype
 support, so installing the ``lean.vim`` (i.e. non-neovim) plugin is not

--- a/autoload/tcomment/types/lean.vim
+++ b/autoload/tcomment/types/lean.vim
@@ -1,0 +1,4 @@
+for ft in ['lean', 'lean3']
+    call tcomment#type#Define(ft, '-- %s')
+    call tcomment#type#Define(ft .. '_block', '/-%s-/')
+endfor

--- a/lua/tests/language_support_spec.lua
+++ b/lua/tests/language_support_spec.lua
@@ -2,24 +2,38 @@
 --- Tests for basic Lean language support.
 ---@brief ]]
 
+local dedent = require('lean._util').dedent
 local helpers = require('tests.helpers')
 
 require('lean').setup{}
 
-describe('commenting', function()
-  it('comments out single lines', helpers.clean_buffer('lean', 'def best := 37', function()
+for _, ft in pairs({"lean3", "lean"}) do
+describe(ft .. ' commenting', function()
+  it('comments out single lines', helpers.clean_buffer(ft, 'def best := 37', function()
     vim.cmd('TComment')
-    assert.is.same(
-      '/- def best := 37 -/',
-      vim.api.nvim_get_current_line()
-    )
+    assert.contents.are('-- def best := 37')
   end))
 
-  it('comments out single lines in lean 3', helpers.clean_buffer('lean3', 'def best := 37', function()
-    vim.cmd('TComment')
-    assert.is.same(
-      '/- def best := 37 -/',
-      vim.api.nvim_get_current_line()
-    )
+  it('comments out multiple lines inline by default', helpers.clean_buffer(ft, [[
+def foo := 12
+def bar := 37]], function()
+    vim.cmd(':% TComment')
+    assert.contents.are(dedent[[
+      -- def foo := 12
+      -- def bar := 37
+    ]])
+  end))
+
+  it('can comment out block comments', helpers.clean_buffer(ft, [[
+def foo := 12
+def bar := 37]], function()
+    vim.cmd(':% TCommentBlock')
+    assert.contents.are(dedent[[
+      /-
+      def foo := 12
+      def bar := 37
+      -/
+    ]])
   end))
 end)
+end


### PR DESCRIPTION
Makes commenting inline the default, but supports block
comments via TCommentBlock.

We could also upstream this obviously.