### PR TITLE
Add a way to granularly configure when infoviews open.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -291,6 +291,11 @@ Full Configuration & Settings Information
       -- Infoview support
       infoview = {
         -- Automatically open an infoview on entering a Lean buffer?
+        -- Should be a function that will be called anytime a new Lean file
+        -- is opened. Return true to open an infoview, otherwise false.
+        -- Setting this to `true` is the same as `function() return true end`,
+        -- i.e. autoopen for any Lean file, or setting it to `false` is the
+        -- same as `function() return false end`, i.e. never autoopen.
         autoopen = true,
 
         -- Set infoview windows' starting dimensions.

--- a/lua/lean/infoview.lua
+++ b/lua/lean/infoview.lua
@@ -933,6 +933,7 @@ function infoview.enable(opts)
   options = vim.tbl_extend("force", options._DEFAULTS, opts)
   infoview.mappings = options.mappings
   infoview.enabled = true
+  infoview.set_autoopen(options.autoopen)
   set_augroup("LeanInfoviewInit", [[
     autocmd FileType lean3 lua require'lean.infoview'.make_buffer_focusable(vim.fn.expand('<afile>'))
     autocmd FileType lean lua require'lean.infoview'.make_buffer_focusable(vim.fn.expand('<afile>'))
@@ -961,6 +962,11 @@ end
 
 --- Set whether a new infoview is automatically opened when entering Lean buffers.
 function infoview.set_autoopen(autoopen)
+  if autoopen == true then
+    autoopen = function() return true end
+  elseif autoopen == false then
+    autoopen = function() return false end
+  end
   options.autoopen = autoopen
 end
 
@@ -994,7 +1000,7 @@ function infoview.__maybe_autoopen()
   if infoview._by_tabpage[tabpage] then return end
   local new_infoview = Infoview:new{}
   infoview._by_tabpage[tabpage] = new_infoview
-  if options.autoopen then new_infoview:open() end
+  if options.autoopen() then new_infoview:open() end
 end
 
 function infoview.open()

--- a/lua/tests/infoview/autoopen_custom_spec.lua
+++ b/lua/tests/infoview/autoopen_custom_spec.lua
@@ -1,0 +1,33 @@
+---@brief [[
+--- Tests for infoview autoopen as a function (where its return value decides
+--- whether to open the new infoview or not).
+---@brief ]]
+require('tests.helpers')
+local infoview = require('lean.infoview')
+local fixtures = require('tests.fixtures')
+
+local should_autoopen = false
+
+require('lean').setup{
+  infoview = { autoopen = function() return should_autoopen end }
+}
+
+describe('infoview custom autoopen', function()
+  local lean_window
+
+  it('uses the configured function to decide whether to autoopen', function()
+    assert.is.equal(1, #vim.api.nvim_tabpage_list_wins(0))
+    lean_window = vim.api.nvim_get_current_win()
+
+    vim.cmd('edit! ' .. fixtures.lean3_project.some_existing_file)
+    assert.are.same_elements({ lean_window }, vim.api.nvim_tabpage_list_wins(0))
+
+    should_autoopen = true
+
+    vim.cmd('edit! ' .. fixtures.lean3_project.some_existing_file)
+    assert.are.same_elements(
+      { lean_window, infoview.get_current_infoview().window },
+      vim.api.nvim_tabpage_list_wins(0)
+    )
+  end)
+end)


### PR DESCRIPTION
Set `autoopen` to a function (which returns true or false) to decide
whether to open an infoview, and inspect the world before doing so.

E.g., if you don't want infoviews to open if there's a non-Lean
window already open, use:

```lua
    require('lean').setup{
      infoview = {
        autoopen = function()
          for _, window in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
            local buf = vim.api.nvim_win_get_buf(window)
            local name = vim.api.nvim_buf_get_name(buf)
            if not name:match('.*%.lean') then return false end
          end
          return true
        end
      },
    }
```

Closes: #171