### PR TITLE
Add basic highlighting for Lean 3 tactics.

### DIFF
--- a/ftplugin/lean/lean.lua
+++ b/ftplugin/lean/lean.lua
@@ -3,7 +3,7 @@ vim.b.did_ftplugin = 1
 
 vim.opt.wildignore:append[[*.olean]]
 
-vim.opt_local.iskeyword = [[@,48-57,_,-,!,#,$,%]]
+vim.opt_local.iskeyword = [[@,48-57,_,-,.,!,#,$,%]]
 vim.opt_local.comments = [[s0:/-,mb:\ ,ex:-/,:--]]
 vim.opt_local.commentstring=[[/- %s -/]]
 

--- a/ftplugin/lean3/lean.lua
+++ b/ftplugin/lean3/lean.lua
@@ -3,7 +3,7 @@ vim.b.did_ftplugin = 1
 
 vim.opt.wildignore:append[[*.olean]]
 
-vim.opt_local.iskeyword = [[@,48-57,_,-,!,#,$,%]]
+vim.opt_local.iskeyword = [[@,48-57,_,-,.,!,#,$,%]]
 vim.opt_local.comments = [[s0:/-,mb:\ ,ex:-/,:--]]
 vim.opt_local.commentstring=[[/- %s -/]]
 

--- a/syntax/lean.vim
+++ b/syntax/lean.vim
@@ -28,7 +28,7 @@ syn keyword leanCommand precedence postfix prefix notation infix infixl infixr
 syn keyword leanKeyword by end
 syn keyword leanKeyword forall fun from have show assume suffices let if else then in with calc match do this
 syn keyword leanKeyword try catch finally for unless return mut continue break
-syn keyword leanKeyword Sort Prop Type
+syn keyword leanSort Sort Prop Type
 syn keyword leanCommand set_option run_cmd
 syn match leanCommand "#eval"
 syn match leanCommand "#check"
@@ -36,6 +36,7 @@ syn match leanCommand "#print"
 syn match leanCommand "#reduce"
 
 syn keyword leanSorry sorry
+syn keyword leanSorry admit
 syn match leanSorry "#exit"
 
 syn region leanAttributeArgs start='\[' end='\]' contained contains=leanString,leanNumber,leanAttributeArgs
@@ -93,6 +94,7 @@ hi def link leanComment           Comment
 hi def link leanBlockComment      leanComment
 
 hi def link leanKeyword           Keyword
+hi def link leanSort              Type
 hi def link leanCommand           leanKeyword
 hi def link leanCommandPrefix     PreProc
 hi def link leanAttributeArgs     leanCommandPrefix
@@ -113,8 +115,8 @@ hi def link leanNameLiteral       Identifier
 
 hi def link leanSorry             Error
 
-hi def link leanPinned        DiagnosticUnderlineHint
-hi def link leanDiffPinned    DiagnosticUnderlineInfo
+hi def link leanPinned            DiagnosticUnderlineHint
+hi def link leanDiffPinned        DiagnosticUnderlineInfo
 
 syn sync minlines=200
 syn sync maxlines=500

--- a/syntax/lean3.vim
+++ b/syntax/lean3.vim
@@ -71,7 +71,7 @@ syn region leanTacticMode matchgroup=Label start='\<begin\>' end='\<end\>'
     \ contains=ALLBUT,leanDeclarationName,leanEncl,leanAttributeArgs
 
 syn keyword leanKeyword end
-syn keyword leanKeyword forall fun Pi from have show assume suffices let if else then in with calc match do this
+syn keyword leanKeyword forall fun Pi from have show assume suffices let if else then in calc match do this
 syn keyword leanSort Sort Prop Type
 syn keyword leanCommand set_option run_cmd
 syn match leanCommand "#eval"

--- a/syntax/lean3.vim
+++ b/syntax/lean3.vim
@@ -9,7 +9,7 @@ syn case match
 
 syn keyword leanCommand prelude import include omit export open open_locale mutual
 syn keyword leanCommandPrefix local localized private protected noncomputable meta
-syn keyword leanModifier renaming hiding where extends using with at rec deriving
+syn keyword leanModifier renaming hiding where extends using with at only rec deriving
 
 syn keyword leanCommand namespace section
 
@@ -24,9 +24,55 @@ syn keyword leanCommand universe universes example axioms constants
 syn keyword leanCommand meta parameter parameters variable variables
 syn keyword leanCommand reserve precedence postfix prefix notation infix infixl infixr
 
-syn keyword leanKeyword begin by end
+syn keyword leanTactic
+        \ abel abstract ac_mono ac_refl all_goals any_goals apply
+        \ apply_assumption apply_auto_param apply_congr apply_fun
+        \ apply_instance apply_opt_param apply_rules apply_with
+        \ assoc_rewrite assume assumption async by_cases by_contra
+        \ by_contradiction calc cancel_denoms case cases cases_matching
+        \ casesm cases_type cc change choose classical clear
+        \ clear_aux_decl clear_except clear_value comp_val congr
+        \ constructor continuity contradiction contrapose conv to_lhs
+        \ to_rhs convert convert_to dec_trivial delta destruct done
+        \ dsimp dunfold eapply econstructor elide unelide equiv_rw
+        \ equiv_rw_type erewrite erw exact exacts exfalso existsi
+        \ ext1 ext extract_goal fail_if_success fapply fconstructor
+        \ field_simp filter_upwards fin_cases finish clarify safe
+        \ focus from fsplit funext generalize generalize_hyp
+        \ generalize_proofs generalizes group guard_hyp guard_target
+        \ h_generalize have hint induction inhabit injection injections
+        \ injections_and_clear interval_cases intro intros introv
+        \ itauto iterate left right let library_search lift linarith
+        \ linear_combination mapply match_target measurability mono
+        \ nlinarith noncomm_ring nontriviality norm_cast norm_fin
+        \ norm_num nth_rewrite nth_rewrite_lhs nth_rewrite_rhs observe
+        \ obtain omega pi_instance pretty_cases push_neg rcases refine
+        \ refine_struct refl reflexivity rename rename_var repeat
+        \ replace revert revert_after revert_deps revert_target_deps
+        \ rewrite_search ring ring2 ring_exp rintro rintros rotate rw
+        \ rewrite rwa scc show show_term simp simp_intros simp_result
+        \ simp_rw simpa skip slice solve1 solve_by_elim
+        \ specialize split split_ifs squeeze_simp squeeze_simpa
+        \ squeeze_dsimp squeeze_scope subst subst_vars substs
+        \ subtype_instance success_if_fail suffices suggest swap
+        \ swap_var symmetry tautology tfae tidy trace trace_simp_set
+        \ trace_state transitivity transport triv trivial trunc_cases
+        \ try type_check unfold unfold1 unfold_cases unfold_coes
+        \ unfold_projs unify_equations use with_cases wlog zify
+        \ resetI unfreezingI introI introsI casesI substI haveI letI exactI
+        \ contained
+" Try to highlight `set` the tactic while ignoring set-the-type annotation
+syn match  leanTactic '\<set \(\k\+)\)\@!'
+syn match  leanSemi ';' skipwhite skipempty contained nextgroup=leanTacticBlock,leanTactic,leanSorry
+syn match  leanBy '\<by\>' skipwhite skipempty nextgroup=leanTacticBlock,leanTactic,leanSorry
+syn region leanTacticBlock start='{' end='}' contained
+    \ contains=ALLBUT,leanDeclarationName,leanEncl,leanAttributeArgs
+syn region leanTacticMode matchgroup=Label start='\<begin\>' end='\<end\>'
+    \ contains=ALLBUT,leanDeclarationName,leanEncl,leanAttributeArgs
+
+syn keyword leanKeyword end
 syn keyword leanKeyword forall fun Pi from have show assume suffices let if else then in with calc match do this
-syn keyword leanKeyword Sort Prop Type
+syn keyword leanSort Sort Prop Type
 syn keyword leanCommand set_option run_cmd
 syn match leanCommand "#eval"
 syn match leanCommand "#check"
@@ -34,6 +80,7 @@ syn match leanCommand "#print"
 syn match leanCommand "#reduce"
 
 syn keyword leanSorry sorry
+syn keyword leanSorry admit
 syn match leanSorry "#exit"
 
 syn region leanAttributeArgs start='\[' end='\]' contained contains=leanString,leanNumber,leanAttributeArgs
@@ -41,7 +88,7 @@ syn match leanCommandPrefix '@' nextgroup=leanAttributeArgs
 syn keyword leanCommandPrefix attribute skipwhite nextgroup=leanAttributeArgs
 
 " constants
-syn match leanOp "[:=><λ←→↔∀∃∧∨¬≤≥▸·+*-/;$|&%!×]"
+syn match leanOp "[:=><λ←→↔∀∃∧∨¬≤≥▸·+*-/$|&%!×]"
 syn match leanOp '\([A-Za-z]\)\@<!?'
 
 " delimiters
@@ -87,7 +134,10 @@ hi def link leanComment           Comment
 hi def link leanBlockComment      leanComment
 
 hi def link leanKeyword           Keyword
+hi def link leanSort              Type
 hi def link leanCommand           leanKeyword
+hi def link leanTactic            Keyword
+hi def link leanBy                Label
 hi def link leanCommandPrefix     PreProc
 hi def link leanAttributeArgs     leanCommandPrefix
 hi def link leanModifier          Label
@@ -96,6 +146,7 @@ hi def link leanDeclaration       leanCommand
 hi def link leanDeclarationName   Function
 
 hi def link leanDelim             Delimiter
+hi def link leanSemi              Delimiter
 hi def link leanOp                Operator
 
 hi def link leanNotation          String
@@ -107,8 +158,8 @@ hi def link leanNameLiteral       Identifier
 
 hi def link leanSorry             Error
 
-hi def link leanPinned        DiagnosticUnderlineHint
-hi def link leanDiffPinned    DiagnosticUnderlineInfo
+hi def link leanPinned            DiagnosticUnderlineHint
+hi def link leanDiffPinned        DiagnosticUnderlineInfo
 
 syn sync minlines=200
 syn sync maxlines=500


### PR DESCRIPTION
~~(Doesn't even bother doing this only in tactic mode -- so `have` and `let` and friends I left off the list and therefore will look a bit odd perhaps, but we can obviously improve).~~

Just copies the list from the mathlib docs.

To modify the color used (e.g. if you don't like it matching the names
of declarations), do e.g. `highlight link leanTactic Green` in your configuration.
Some other languages these days seem to be choosing to do so directly in their syntax
files rather than link to the semantic ones...

~~I didn't do Lean 4 since I was lazy and didn't read https://github.com/leanprover-community/mathlib4/blob/master/Mathlib/Mathport/Syntax.lean carefully to see if the naming is staying similar or all tactics are being ported. Obviously can do so if needed.~~