### PR TITLE
Consider . a keyword char only for syntax highlighting.

### DIFF
--- a/ftplugin/lean/lean.lua
+++ b/ftplugin/lean/lean.lua
@@ -3,7 +3,7 @@ vim.b.did_ftplugin = 1
 
 vim.opt.wildignore:append[[*.olean]]
 
-vim.opt_local.iskeyword = [[@,48-57,_,-,.,!,#,$,%]]
+vim.opt_local.iskeyword = [[a-z,A-Z,_,48-57,192-255,!]]
 vim.opt_local.comments = [[s0:/-,mb:\ ,ex:-/,:--]]
 vim.opt_local.commentstring=[[/- %s -/]]
 

--- a/ftplugin/lean3/lean.lua
+++ b/ftplugin/lean3/lean.lua
@@ -3,7 +3,7 @@ vim.b.did_ftplugin = 1
 
 vim.opt.wildignore:append[[*.olean]]
 
-vim.opt_local.iskeyword = [[@,48-57,_,-,.,!,#,$,%]]
+vim.opt_local.iskeyword = [[a-z,A-Z,_,48-57,192-255,!]]
 vim.opt_local.comments = [[s0:/-,mb:\ ,ex:-/,:--]]
 vim.opt_local.commentstring=[[/- %s -/]]
 

--- a/syntax/lean.vim
+++ b/syntax/lean.vim
@@ -5,6 +5,9 @@
 
 syn case match
 
+" Add . to keywords for syntax purposes
+syn iskeyword a-z,A-Z,_,48-57,192-255,!,.
+
 " keywords
 
 syn keyword leanCommand prelude import include export open mutual

--- a/syntax/lean3.vim
+++ b/syntax/lean3.vim
@@ -5,6 +5,9 @@
 
 syn case match
 
+" Add . to keywords for syntax purposes
+syn iskeyword a-z,A-Z,_,48-57,192-255,!,.
+
 " keywords
 
 syn keyword leanCommand prelude import include omit export open open_locale mutual


### PR DESCRIPTION
@gebner FYI -- you sounded like you were maybe saying you thought *with* `.` was better somehow, let me know if so? It was just me being lazy before and not figuring out how to use `syn iskeyword`. But looks like that's trivial.

(Also I removed `#`, `$` and `%` which Lean doesn't allow.)