### PR TITLE
Add helper for better test synchronization.

### DIFF
--- a/lua/lean/progress.lua
+++ b/lua/lean/progress.lua
@@ -11,6 +11,18 @@ function M.is_processing(uri)
     return M.proc_infos[uri] and not vim.tbl_isempty(M.proc_infos[uri])
   end
 
+function M.test_is_processing_at(params)
+  local this_proc_info = M.proc_infos[params.textDocument.uri]
+  if not this_proc_info then return true end
+  for _, range in pairs(this_proc_info) do
+    -- ignoring character for now (seems to always be 0)
+    if (params.position.line <= range.range["end"].line) and (params.position.line >= range.range.start.line) then
+      return true
+    end
+  end
+  return false
+end
+
 function M.is_processing_at(params)
   local this_proc_info = M.proc_infos[params.textDocument.uri]
   -- returning false rather than true for backwards compatibility with

--- a/lua/tests/ft_spec.lua
+++ b/lua/tests/ft_spec.lua
@@ -27,7 +27,7 @@ describe('ft.detect', function()
     local initial_path = vim.api.nvim_buf_get_name(0)
 
     vim.api.nvim_command('normal G$')
-    helpers.wait_for_infoview_contents(': Type')
+    helpers.wait_for_loading_pins()
 
     vim.lsp.buf.definition()
     assert.is_truthy(vim.wait(5000, function() return vim.api.nvim_buf_get_name(0) ~= initial_path end))
@@ -54,6 +54,10 @@ describe('ft.detect', function()
     local initial_path = vim.api.nvim_buf_get_name(0)
 
     vim.api.nvim_command('normal G$')
+    -- FIXME When I run this locally with `wait_for_loading_pins` instead,
+    -- it fails (never finishes processing). It looks like the only reason
+    -- this check works because it's getting these contents from the
+    -- diagnostics, rather than the pins themselves (which don't actually load).
     helpers.wait_for_infoview_contents(': Type')
 
     vim.lsp.buf.definition()

--- a/lua/tests/helpers.lua
+++ b/lua/tests/helpers.lua
@@ -48,6 +48,17 @@ function helpers.move_cursor(opts)
   vim.cmd[[doautocmd CursorMoved]]
 end
 
+function helpers.wait_for_loading_pins()
+  local info = infoview.get_current_infoview().info
+  local succeeded, _ = vim.wait(5000, function()
+    for _, pin in pairs(vim.list_extend({info.pin, info.__diff_pin}, info.pins)) do
+      if pin.loading or require"lean.progress".test_is_processing_at(pin.__position_params)  then return false end
+    end
+    return true
+  end)
+  assert.message('Pins never finished loading.').True(succeeded)
+end
+
 function helpers.wait_for_ready_lsp()
   local succeeded, _ = vim.wait(5000, vim.lsp.buf.server_ready)
   assert.message('LSP server was never ready.').True(succeeded)

--- a/lua/tests/helpers.lua
+++ b/lua/tests/helpers.lua
@@ -70,7 +70,8 @@ function helpers.wait_for_loading_pins(iv)
   local msg = last_loading and "loading" or ""
   if last_loading and last_processing then msg = msg .. "/" end
   msg = msg .. (last_processing and "processing" or "")
-  assert.message(string.format('Pin %s never finished %s.', tostring(last) or "", msg)).True(succeeded)
+  assert.message(string.format('Pin %s never finished %s.',
+    tostring(last) or "", msg)).True(succeeded)
 end
 
 function helpers.wait_for_ready_lsp()

--- a/lua/tests/infoview/contents_spec.lua
+++ b/lua/tests/infoview/contents_spec.lua
@@ -293,6 +293,19 @@ describe('infoview content (auto-)update', function()
 
       it('shows a term goal', function()
         helpers.move_cursor{ to = {3, 27} }
+        -- FIXME: There is a race condition here which likely is an actual
+        --        (minor) bug. In CI, which is slower than locally, the below
+        --        will often flakily fail without the pcall-and-retry. This
+        --        likely is the update starting too early, and should be
+        --        detected (and delayed) in the real code, but for now it's
+        --        just hacked around here.
+        local succeeded, _ = pcall(helpers.wait_for_infoview_contents, 'expected type')
+        if not succeeded then
+          -- move away and back to retry
+          helpers.move_cursor{ to = {2, 0} }
+          helpers.move_cursor{ to = {3, 27} }
+          helpers.wait_for_infoview_contents('expected type')
+        end
 
         assert.infoview_contents.are[[
           ▶ expected type:

--- a/lua/tests/infoview/contents_spec.lua
+++ b/lua/tests/infoview/contents_spec.lua
@@ -38,7 +38,6 @@ describe('infoview content (auto-)update', function()
     -- In theory we don't care where we are, but the right answer changes
     assert.are.same(vim.api.nvim_win_get_cursor(0), {1, 0})
 
-    helpers.wait_for_infoview_contents('\n1')
     -- FIXME: Trailing extra newline.
     assert.infoview_contents.are[[
       ▶ 1:1-1:6: information:
@@ -51,7 +50,6 @@ describe('infoview content (auto-)update', function()
     assert.are_not.same(vim.api.nvim_win_get_cursor(0), {3, 0})
 
     helpers.move_cursor{ to = {3, 0} }
-    helpers.wait_for_infoview_contents('\n9')
     -- FIXME: Trailing extra newline.
     assert.infoview_contents.are[[
       ▶ 3:1-3:6: information:
@@ -66,7 +64,6 @@ describe('infoview content (auto-)update', function()
     vim.cmd('split')
     local second_window = vim.api.nvim_get_current_win()
     assert.are.same(vim.api.nvim_win_get_cursor(0), {3, 0})
-    helpers.wait_for_infoview_contents('\n9')
     assert.infoview_contents.are[[
       ▶ 3:1-3:6: information:
       9.000000
@@ -74,7 +71,6 @@ describe('infoview content (auto-)update', function()
     ]]
 
     helpers.move_cursor{ to = {1, 0} }
-    helpers.wait_for_infoview_contents('\n1')
     assert.infoview_contents.are[[
       ▶ 1:1-1:6: information:
       1
@@ -83,7 +79,6 @@ describe('infoview content (auto-)update', function()
 
     -- Now switch back to the other window and...
     vim.cmd[[wincmd p]]
-    helpers.wait_for_infoview_contents('\n9')
     assert.infoview_contents.are[[
       ▶ 3:1-3:6: information:
       9.000000
@@ -116,7 +111,6 @@ describe('infoview content (auto-)update', function()
     helpers.move_cursor{ to = {1, 0} }
 
     infoview.get_current_infoview():open()
-    helpers.wait_for_infoview_contents('\n1')
     assert.infoview_contents.are[[
       ▶ 1:1-1:6: information:
       1
@@ -124,7 +118,6 @@ describe('infoview content (auto-)update', function()
     ]]
 
     helpers.move_cursor{ to = {3, 0} }
-    helpers.wait_for_infoview_contents('\n9')
     assert.infoview_contents.are[[
       ▶ 3:1-3:6: information:
       9.000000
@@ -152,7 +145,6 @@ describe('infoview content (auto-)update', function()
       assert.windows.are(lean_window, tab1_infoview.window)
 
       helpers.move_cursor{ to = {1, 0} }
-      helpers.wait_for_infoview_contents('\n1')
       assert.infoview_contents.are[[
         ▶ 1:1-1:6: information:
         1
@@ -161,7 +153,6 @@ describe('infoview content (auto-)update', function()
 
       vim.cmd('tabnew' .. fixtures.lean_project.path .. '/Test/Squares.lean')
       helpers.move_cursor{ to = {3, 0} }
-      helpers.wait_for_infoview_contents('\n9')
       assert.infoview_contents.are[[
         ▶ 3:1-3:6: information:
         9.000000
@@ -187,7 +178,6 @@ describe('infoview content (auto-)update', function()
       vim.cmd('tabprevious')
 
       helpers.move_cursor{ to = {3, 0} }
-      helpers.wait_for_infoview_contents('\n9')
       assert.infoview_contents.are[[
         ▶ 3:1-3:6: information:
         9.000000
@@ -195,7 +185,6 @@ describe('infoview content (auto-)update', function()
       ]]
 
       helpers.move_cursor{ to = {1, 0} }
-      helpers.wait_for_infoview_contents('\n1')
       assert.infoview_contents.are[[
         ▶ 1:1-1:6: information:
         1
@@ -217,7 +206,6 @@ describe('infoview content (auto-)update', function()
 
       it('shows a term goal', function()
         helpers.move_cursor{ to = {3, 27} }
-        helpers.wait_for_infoview_contents('expected type')
         assert.infoview_contents.are[[
           ▶ expected type (3:28-3:36)
           ⊢ Nat
@@ -226,7 +214,6 @@ describe('infoview content (auto-)update', function()
 
       it('shows a tactic goal', function()
         helpers.move_cursor{ to = {6, 0} }
-        helpers.wait_for_infoview_contents('1 goal')
         assert.infoview_contents.are[[
           ▶ 1 goal
           p q : Prop
@@ -236,7 +223,6 @@ describe('infoview content (auto-)update', function()
 
       it('shows mixed goals', function()
         helpers.move_cursor{ to = {7, 8} }
-        helpers.wait_for_infoview_contents('7:9')
         assert.infoview_contents.are[[
           ▶ 1 goal
           p q : Prop
@@ -252,7 +238,6 @@ describe('infoview content (auto-)update', function()
 
       it('shows multiple goals', function()
         helpers.move_cursor{ to = {17, 2} }
-        helpers.wait_for_infoview_contents('goals')
         assert.infoview_contents.are[[
           ▶ 2 goals
           case zero
@@ -266,7 +251,6 @@ describe('infoview content (auto-)update', function()
 
       it('properly handles multibyte characters', function()
         helpers.move_cursor{ to = {20, 62} }
-        helpers.wait_for_infoview_contents('expected type')
         assert.infoview_contents.are[[
           ▶ expected type (20:54-20:57)
           𝔽 : Type
@@ -274,12 +258,10 @@ describe('infoview content (auto-)update', function()
         ]]
 
         helpers.move_cursor{ to = {20, 58} }
-        helpers.wait_for_infoview_contents('^$')
         assert.infoview_contents.are[[
         ]]
 
         helpers.move_cursor{ to = {20, 60} }
-        helpers.wait_for_infoview_contents('expected type')
         assert.infoview_contents.are[[
           ▶ expected type (20:54-20:57)
           𝔽 : Type
@@ -293,13 +275,11 @@ describe('infoview content (auto-)update', function()
         ---        even before being refactored though, as it passes with or without the relevant
         ---        lines in infoview.lua)
         helpers.move_cursor{ to = {23, 1} }
-        helpers.wait_for_infoview_contents('37')
         assert.infoview_contents.are[[
           ▶ 1 goal
           ⊢ 37 = 37
         ]]
         vim.api.nvim_buf_set_lines(0, 21, 22, true, {"def will_be_modified : 2 = 2 := by"})
-        helpers.wait_for_infoview_contents('2')
         assert.infoview_contents.are[[
           ▶ 1 goal
           ⊢ 2 = 2
@@ -313,19 +293,6 @@ describe('infoview content (auto-)update', function()
 
       it('shows a term goal', function()
         helpers.move_cursor{ to = {3, 27} }
-        -- FIXME: There is a race condition here which likely is an actual
-        --        (minor) bug. In CI, which is slower than locally, the below
-        --        will often flakily fail without the pcall-and-retry. This
-        --        likely is the update starting too early, and should be
-        --        detected (and delayed) in the real code, but for now it's
-        --        just hacked around here.
-        local succeeded, _ = pcall(helpers.wait_for_infoview_contents, 'expected type')
-        if not succeeded then
-          -- move away and back to retry
-          helpers.move_cursor{ to = {2, 0} }
-          helpers.move_cursor{ to = {3, 27} }
-          helpers.wait_for_infoview_contents('expected type')
-        end
 
         assert.infoview_contents.are[[
           ▶ expected type:
@@ -335,7 +302,6 @@ describe('infoview content (auto-)update', function()
 
       it('shows a tactic goal', function()
         helpers.move_cursor{ to = {6, 0} }
-        helpers.wait_for_infoview_contents('1 goal')
         -- FIXME: extra internal newline compared to Lean 4
         assert.infoview_contents.are[[
           filter: no filter
@@ -347,7 +313,6 @@ describe('infoview content (auto-)update', function()
 
       it('shows multiple goals', function()
         helpers.move_cursor{ to = {20, 2} }
-        helpers.wait_for_infoview_contents('goals')
         assert.infoview_contents.are[[
           filter: no filter
           ▶ 2 goals
@@ -363,7 +328,6 @@ describe('infoview content (auto-)update', function()
       if vim.version().major >= 1 or vim.version().minor >= 6 then
         it('properly handles multibyte characters', function()
           helpers.move_cursor{ to = {24, 61} }
-          helpers.wait_for_infoview_contents('expected type')
           assert.infoview_contents.are[[
             ▶ expected type:
             𝔽 : Type
@@ -371,12 +335,10 @@ describe('infoview content (auto-)update', function()
           ]]
 
           helpers.move_cursor{ to = {24, 58} }
-          helpers.wait_for_infoview_contents('^$')
           assert.infoview_contents.are[[
           ]]
 
           helpers.move_cursor{ to = {24, 60} }
-          helpers.wait_for_infoview_contents('expected type')
           assert.infoview_contents.are[[
             ▶ expected type:
             𝔽 : Type
@@ -392,7 +354,7 @@ describe('infoview content (auto-)update', function()
       local uri = vim.uri_from_fname(vim.api.nvim_buf_get_name(0))
       local result = vim.wait(5000, function() return require('lean.progress').is_processing(uri) end)
       assert.message('file was never processing').is_true(result)
-      assert.infoview_contents.are('Processing file...')
+      assert.infoview_contents_nowait.are('Processing file...')
     end)
   end))
 end)

--- a/lua/tests/infoview/pause_spec.lua
+++ b/lua/tests/infoview/pause_spec.lua
@@ -16,7 +16,6 @@ describe('infoview pause/unpause', function()
   it("can pause and unpause updates", function(_)
     vim.cmd('edit! ' .. fixtures.lean_project.path .. '/Test/Squares.lean')
     helpers.move_cursor{ to = {3, 0} }
-    helpers.wait_for_infoview_contents('\n9')
     -- FIXME: Trailing extra newline.
     assert.infoview_contents.are[[
       ▶ 3:1-3:6: information:
@@ -25,7 +24,6 @@ describe('infoview pause/unpause', function()
     ]]
 
     helpers.move_cursor{ to = {1, 0} }
-    helpers.wait_for_infoview_contents('\n1')
     -- FIXME: Trailing extra newline.
     assert.infoview_contents.are[[
       ▶ 1:1-1:6: information:
@@ -52,7 +50,6 @@ describe('infoview pause/unpause', function()
 
     -- Unpausing triggers an update.
     pin:unpause()
-    helpers.wait_for_infoview_contents('\n9')
     -- FIXME: Trailing extra newline.
     assert.infoview_contents.are[[
       ▶ 3:1-3:6: information:
@@ -62,7 +59,6 @@ describe('infoview pause/unpause', function()
 
     -- And continued movement continues updating.
     helpers.move_cursor{ to = {1, 0} }
-    helpers.wait_for_infoview_contents('\n1')
     -- FIXME: Trailing extra newline.
     assert.infoview_contents.are[[
       ▶ 1:1-1:6: information:

--- a/lua/tests/infoview/pin_spec.lua
+++ b/lua/tests/infoview/pin_spec.lua
@@ -26,7 +26,7 @@ describe('infoview pins', helpers.clean_buffer('lean', dedent[[
 
     first_pin_position = {7, 5}
     helpers.move_cursor{ to = first_pin_position }
-    helpers.wait_for_infoview_contents('case inr')
+    helpers.wait_for_loading_pins()
     assert.infoview_contents.are[[
       ▶ 1 goal
       case inr
@@ -41,7 +41,7 @@ describe('infoview pins', helpers.clean_buffer('lean', dedent[[
     --        existing contents (in which case an immediate assertion here
     --        should be added).
     helpers.move_cursor{ to = {4, 5} }
-    helpers.wait_for_infoview_contents('case inl')
+    helpers.wait_for_loading_pins()
     assert.infoview_contents.are(string.format([[
       ▶ 1 goal
       case inl
@@ -61,7 +61,7 @@ describe('infoview pins', helpers.clean_buffer('lean', dedent[[
     infoview.add_pin()
 
     helpers.move_cursor{ to = {5, 4} }
-    helpers.wait_for_infoview_contents('case inl.h')
+    helpers.wait_for_loading_pins()
     assert.infoview_contents.are(string.format([[
       ▶ 1 goal
       case inl.h
@@ -109,7 +109,7 @@ describe('infoview pins', helpers.clean_buffer('lean', dedent[[
 
     -- Still shows the right contents after a final movement / update
     helpers.move_cursor{ to = {7, 5} }
-    helpers.wait_for_infoview_contents('case inr')
+    helpers.wait_for_loading_pins()
     assert.infoview_contents.are[[
       ▶ 1 goal
       case inr
@@ -127,7 +127,7 @@ describe('infoview pins', helpers.clean_buffer('lean', dedent[[
     infoview.add_pin()
     infoview.clear_pins()
     infoview.add_pin()
-    helpers.wait_for_infoview_contents('case inl.*case inl')
+    helpers.wait_for_loading_pins()
     assert.infoview_contents.are(string.format([[
       ▶ 1 goal
       case inl
@@ -153,7 +153,7 @@ describe('infoview pins', helpers.clean_buffer('lean', dedent[[
     it('moves pin when lines are added above it', function()
       vim.api.nvim_buf_set_lines(0, 0, 0, true, { 'theorem foo : 2 = 2 := rfl', '' })
       helpers.move_cursor{ to = {1, 24} }
-      helpers.wait_for_infoview_contents('expected type.*1 goal')
+      helpers.wait_for_loading_pins()
       assert.infoview_contents.are(string.format([[
         ▶ expected type (1:24-1:27)
         ⊢ 2 = 2
@@ -183,7 +183,7 @@ describe('infoview pins', helpers.clean_buffer('lean', dedent[[
       helpers.move_cursor{ to = {3, 50} }
       vim.api.nvim_buf_set_lines(0, 0, 2, true, {})
 
-      helpers.wait_for_infoview_contents('1 goal.*1 goal')
+      helpers.wait_for_loading_pins()
       assert.infoview_contents.are(string.format([[
         ▶ 1 goal
         p q : Prop
@@ -215,7 +215,7 @@ describe('infoview pins', helpers.clean_buffer('lean', dedent[[
       vim.api.nvim_buf_set_lines(0, -1, -1, true, { '', 'theorem foo : 2 = 2 := rfl' })
 
       helpers.move_cursor{ to = {11, 24} }
-      helpers.wait_for_infoview_contents('expected type.*1 goal')
+      helpers.wait_for_loading_pins()
       assert.infoview_contents.are(string.format([[
         ▶ expected type (11:24-11:27)
         ⊢ 2 = 2
@@ -231,7 +231,7 @@ describe('infoview pins', helpers.clean_buffer('lean', dedent[[
       vim.api.nvim_buf_set_lines(0, 9, 11, true, {})
 
       helpers.move_cursor{ to = {1, 50} }
-      helpers.wait_for_infoview_contents('1 goal.*1 goal')
+      helpers.wait_for_loading_pins()
       assert.infoview_contents.are(string.format([[
         ▶ 1 goal
         p q : Prop
@@ -250,7 +250,7 @@ describe('infoview pins', helpers.clean_buffer('lean', dedent[[
       helpers.move_cursor{ to = {4, 7} }
       vim.cmd[[normal cl37]]  -- h1 -> h37
       helpers.move_cursor{ to = {1, 50} }
-      helpers.wait_for_infoview_contents('1 goal\np.*1 goal.*h37')
+      helpers.wait_for_loading_pins()
       assert.infoview_contents.are(string.format([[
         ▶ 1 goal
         p q : Prop
@@ -267,10 +267,9 @@ describe('infoview pins', helpers.clean_buffer('lean', dedent[[
 
     it('does not move pin when changes are made on its line after its column', function()
       helpers.move_cursor{ to = {4, 13} }
-      helpers.wait_for_infoview_contents('case inl.*case inl')
       vim.cmd[[normal a    ]]
       helpers.move_cursor{ to = {1, 50} }
-      helpers.wait_for_infoview_contents('1 goal\np.*1 goal.*h37')
+      helpers.wait_for_loading_pins()
       assert.infoview_contents.are(string.format([[
         ▶ 1 goal
         p q : Prop
@@ -302,9 +301,8 @@ describe('infoview pins', helpers.clean_buffer('lean', dedent[[
       assert.windows.are(lean_window, current_infoview.window)
 
       helpers.move_cursor{ to = {4, 5} }
-      helpers.wait_for_infoview_contents('case inl')
       infoview.set_diff_pin()
-      helpers.wait_for_diff_contents('case inl')
+      helpers.wait_for_loading_pins()
 
       assert.infoview_contents.are[[
         ▶ 1 goal
@@ -332,8 +330,7 @@ describe('infoview pins', helpers.clean_buffer('lean', dedent[[
 
     it('maintains separate text', function()
       helpers.move_cursor{ to = {5, 5} }
-      helpers.wait_for_infoview_contents('case inl.h')
-      helpers.wait_for_diff_contents('case inl')
+      helpers.wait_for_loading_pins()
 
       assert.infoview_contents.are[[
         ▶ 1 goal

--- a/lua/tests/infoview/pin_spec.lua
+++ b/lua/tests/infoview/pin_spec.lua
@@ -26,7 +26,6 @@ describe('infoview pins', helpers.clean_buffer('lean', dedent[[
 
     first_pin_position = {7, 5}
     helpers.move_cursor{ to = first_pin_position }
-    helpers.wait_for_loading_pins()
     assert.infoview_contents.are[[
       ▶ 1 goal
       case inr
@@ -41,7 +40,6 @@ describe('infoview pins', helpers.clean_buffer('lean', dedent[[
     --        existing contents (in which case an immediate assertion here
     --        should be added).
     helpers.move_cursor{ to = {4, 5} }
-    helpers.wait_for_loading_pins()
     assert.infoview_contents.are(string.format([[
       ▶ 1 goal
       case inl
@@ -61,7 +59,6 @@ describe('infoview pins', helpers.clean_buffer('lean', dedent[[
     infoview.add_pin()
 
     helpers.move_cursor{ to = {5, 4} }
-    helpers.wait_for_loading_pins()
     assert.infoview_contents.are(string.format([[
       ▶ 1 goal
       case inl.h
@@ -109,7 +106,6 @@ describe('infoview pins', helpers.clean_buffer('lean', dedent[[
 
     -- Still shows the right contents after a final movement / update
     helpers.move_cursor{ to = {7, 5} }
-    helpers.wait_for_loading_pins()
     assert.infoview_contents.are[[
       ▶ 1 goal
       case inr
@@ -127,7 +123,6 @@ describe('infoview pins', helpers.clean_buffer('lean', dedent[[
     infoview.add_pin()
     infoview.clear_pins()
     infoview.add_pin()
-    helpers.wait_for_loading_pins()
     assert.infoview_contents.are(string.format([[
       ▶ 1 goal
       case inl
@@ -153,7 +148,6 @@ describe('infoview pins', helpers.clean_buffer('lean', dedent[[
     it('moves pin when lines are added above it', function()
       vim.api.nvim_buf_set_lines(0, 0, 0, true, { 'theorem foo : 2 = 2 := rfl', '' })
       helpers.move_cursor{ to = {1, 24} }
-      helpers.wait_for_loading_pins()
       assert.infoview_contents.are(string.format([[
         ▶ expected type (1:24-1:27)
         ⊢ 2 = 2
@@ -183,7 +177,6 @@ describe('infoview pins', helpers.clean_buffer('lean', dedent[[
       helpers.move_cursor{ to = {3, 50} }
       vim.api.nvim_buf_set_lines(0, 0, 2, true, {})
 
-      helpers.wait_for_loading_pins()
       assert.infoview_contents.are(string.format([[
         ▶ 1 goal
         p q : Prop
@@ -215,7 +208,6 @@ describe('infoview pins', helpers.clean_buffer('lean', dedent[[
       vim.api.nvim_buf_set_lines(0, -1, -1, true, { '', 'theorem foo : 2 = 2 := rfl' })
 
       helpers.move_cursor{ to = {11, 24} }
-      helpers.wait_for_loading_pins()
       assert.infoview_contents.are(string.format([[
         ▶ expected type (11:24-11:27)
         ⊢ 2 = 2
@@ -231,7 +223,6 @@ describe('infoview pins', helpers.clean_buffer('lean', dedent[[
       vim.api.nvim_buf_set_lines(0, 9, 11, true, {})
 
       helpers.move_cursor{ to = {1, 50} }
-      helpers.wait_for_loading_pins()
       assert.infoview_contents.are(string.format([[
         ▶ 1 goal
         p q : Prop
@@ -250,7 +241,6 @@ describe('infoview pins', helpers.clean_buffer('lean', dedent[[
       helpers.move_cursor{ to = {4, 7} }
       vim.cmd[[normal cl37]]  -- h1 -> h37
       helpers.move_cursor{ to = {1, 50} }
-      helpers.wait_for_loading_pins()
       assert.infoview_contents.are(string.format([[
         ▶ 1 goal
         p q : Prop
@@ -269,7 +259,6 @@ describe('infoview pins', helpers.clean_buffer('lean', dedent[[
       helpers.move_cursor{ to = {4, 13} }
       vim.cmd[[normal a    ]]
       helpers.move_cursor{ to = {1, 50} }
-      helpers.wait_for_loading_pins()
       assert.infoview_contents.are(string.format([[
         ▶ 1 goal
         p q : Prop
@@ -302,7 +291,6 @@ describe('infoview pins', helpers.clean_buffer('lean', dedent[[
 
       helpers.move_cursor{ to = {4, 5} }
       infoview.set_diff_pin()
-      helpers.wait_for_loading_pins()
 
       assert.infoview_contents.are[[
         ▶ 1 goal
@@ -330,7 +318,6 @@ describe('infoview pins', helpers.clean_buffer('lean', dedent[[
 
     it('maintains separate text', function()
       helpers.move_cursor{ to = {5, 5} }
-      helpers.wait_for_loading_pins()
 
       assert.infoview_contents.are[[
         ▶ 1 goal

--- a/lua/tests/infoview/widgets_spec.lua
+++ b/lua/tests/infoview/widgets_spec.lua
@@ -15,7 +15,6 @@ describe('infoview widgets', function()
 
     it('shows widget tooltips', function(_)
       helpers.move_cursor{ to = {1, 8} }
-      helpers.wait_for_infoview_contents('Nat')
       assert.infoview_contents.are[[
         ▶ expected type (1:8-1:11)
         ⊢ Type
@@ -44,7 +43,7 @@ describe('infoview widgets', function()
       local tab2_window = vim.api.nvim_get_current_win()
       local tab2_infoview = infoview.get_current_infoview()
       helpers.move_cursor{ to = {1, 8} }
-      helpers.wait_for_infoview_contents('Nat')
+      helpers.wait_for_loading_pins()
       vim.api.nvim_set_current_win(tab2_infoview.window)
       helpers.move_cursor{ to = {2, 4} }  -- `Type`
       helpers.feed('<CR>')
@@ -74,7 +73,6 @@ describe('infoview widgets', function()
     -- there, presumably some request getting sent before the server is ready.
     pending('shows widget tooltips', function(_)
       helpers.move_cursor{ to = {1, 10} }
-      helpers.wait_for_infoview_contents('ℕ')
       assert.infoview_contents.are[[
         ▶ expected type:
         ⊢ ℕ
@@ -102,7 +100,6 @@ describe('infoview widgets', function()
     pending('can be disabled', function(_)
       infoview.disable_widgets()
       helpers.move_cursor{ to = {1, 22} }
-      helpers.wait_for_infoview_contents('2 = 2')
       -- we're looking for `filter` to not be shown as our widget
       assert.infoview_contents.are[[
         ▶ 1 goal
@@ -113,7 +110,6 @@ describe('infoview widgets', function()
     pending('can re-enable widgets', function(_)
       infoview.enable_widgets()
       helpers.move_cursor{ to = {1, 22} }
-      helpers.wait_for_infoview_contents('filter')
       -- we're looking for `filter` as our widget
       -- FIXME: Extra newline only with widgets enabled
       assert.infoview_contents.are[[


### PR DESCRIPTION
ISTM that, rather than synchronizing with `wait_for_infoview_contents(...)` to wait for the contents to match after a pin update, we can instead just wait until the infoview's pins are no longer loading or processing. I've only ported `pin_spec.lua` for now as a proof-of-concept, just wanted to first make sure we agree that this is a better way of doing this before going ahead with the full port.