### PR TITLE
Add note for vim non-experts about LocalLeader.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -149,7 +149,7 @@ either within Lean source files or within Infoview windows:
 In Lean Files
 ^^^^^^^^^^^^^
 
-The key binding ``<LocalLeader>`` below refers to a configurable prefix key 
+The key binding ``<LocalLeader>`` below refers to a configurable prefix key
 within vim (and neovim). You can check what this key is set to within neovim
 by running the command ``:echo maplocalleader``. An error like
 ``E121: Undefined variable: maplocalleader`` indicates that it may not be set

--- a/README.rst
+++ b/README.rst
@@ -149,6 +149,14 @@ either within Lean source files or within Infoview windows:
 In Lean Files
 ^^^^^^^^^^^^^
 
+The key binding ``<LocalLeader>`` below refers to a configurable prefix key 
+within vim (and neovim). You can check what this key is set to within neovim
+by running the command ``:echo maplocalleader``. An error like
+``E121: Undefined variable: maplocalleader`` indicates that it may not be set
+to any key. This can be configured by putting a line in your
+``~/.config/nvim/init.vim`` of the form ``let maplocalleader = "\<Space>"``
+(in this example, mapping ``<LocalLeader>`` to ``<Space>``).
+
 +------------------------+----------------------------------------------------+
 |        Key             |                           Function                 |
 +========================+====================================================+


### PR DESCRIPTION
Add a note about how to remap `<LocalLeader>` before the key mappings table in the README.

I am by no means an expert with vim/neovim. Found the use of `<LocalLeader>` in the mappings table very confusing on first look, and the document that the `:help <LocalLeader>` command brings up is massive (over 1500 lines) and mostly irrelevant to using `lean.nvim` out of the box.

Feedback appreciated, not completely sure if this is useful.