### PR TITLE
Update infoview after opening.

### DIFF
--- a/lua/lean/infoview.lua
+++ b/lua/lean/infoview.lua
@@ -1112,6 +1112,7 @@ function infoview.toggle()
   else
     infoview.open()
   end
+  infoview.__update()
 end
 
 --- Toggle whether the current pin receives updates.


### PR DESCRIPTION
When you manually open the infoview, it used to start up blank.  This triggers an update right after it is opened.