### PR TITLE
Add an equivalent of lean4.refreshFileDependencies.

### DIFF
--- a/lua/lean/init.lua
+++ b/lua/lean/init.lua
@@ -64,6 +64,8 @@ function lean.setup(opts)
   if opts.stderr.enable ~= false then require'lean.stderr'.enable(opts.stderr or {}) end
 
   vim.cmd[[
+    command LeanRefreshFileDependencies :lua require'lean.lsp'.refresh_file_dependencies()
+
     command LeanInfoviewToggle :lua require'lean.infoview'.toggle()
     command LeanInfoviewPinTogglePause :lua require'lean.infoview'.pin_toggle_pause()
     command LeanInfoviewAddPin :lua require'lean.infoview'.add_pin()

--- a/lua/lean/lsp.lua
+++ b/lua/lean/lsp.lua
@@ -85,4 +85,21 @@ function lsp.handlers.diagnostics_handler (_, params)
   require"lean.infoview".__update_pin_by_uri(params.uri)
 end
 
+---Refresh file dependencies for an open Lean 4 file.
+---See e.g. https://github.com/leanprover/lean4/blob/master/src/Lean/Server/README.md#recompilation-of-opened-files
+---@param bufnr? number
+function lsp.refresh_file_dependencies(bufnr)
+  bufnr = bufnr or 0
+  local client = lsp.get_lean4_server(bufnr)
+
+  local uri = vim.uri_from_bufnr(bufnr)
+  client.notify('textDocument/didClose', { textDocument = { uri = uri } })
+  client.notify('textDocument/didOpen', { textDocument = {
+      version = 0,
+      uri = uri,
+      languageId = client.config.get_language_id(bufnr, vim.bo.filetype),
+      text = table.concat(vim.api.nvim_buf_get_lines(bufnr, 0, -1, true), '\n')
+  }})
+end
+
 return lsp


### PR DESCRIPTION
Needed for forcibly telling Lean 4 to rebuild dependencies when
editing a dependent file.

:e works but requires writing the file, and will refire Buf-related
events, which may be undesirable.

Ultimately Lean 4 is hopefully planning to obviate the need to do this
manually, but for now this mirrors VSCode.

Closes: #262