### PR TITLE
WIP: `hop.nvim` integration

### DIFF
--- a/lua/lean/infoview.lua
+++ b/lua/lean/infoview.lua
@@ -1188,6 +1188,42 @@ function infoview.go_to()
   end
 end
 
+--- Hop to an interactive infoview element by moving to that element.
+function infoview.hop()
+  local curr_iv = infoview.open()
+  local curr_info = curr_iv.info
+  local opts = {}
+  opts.jump_on_sole_occurrence = false
+  if vim.api.nvim_get_current_win ~= curr_iv.window then
+    opts.multi_windows = true
+  end
+  curr_info.__renderer:hop_to(opts)
+end
+
+--- Hop to an interactive infoview element by going to its definition.
+function infoview.hop_definition()
+  local curr_iv = infoview.open()
+  local curr_info = curr_iv.info
+  local opts = {}
+  opts.jump_on_sole_occurrence = false
+  if vim.api.nvim_get_current_win ~= curr_iv.window then
+    opts.multi_windows = true
+  end
+  curr_info.__renderer:hop_definition(opts)
+end
+
+--- Hop to an interactive infoview element by clicking on it (i.e. LSP hover).
+function infoview.hop_hover()
+  local curr_iv = infoview.open()
+  local curr_info = curr_iv.info
+  local opts = {}
+  opts.jump_on_sole_occurrence = false
+  if vim.api.nvim_get_current_win ~= curr_iv.window then
+    opts.multi_windows = true
+  end
+  curr_info.__renderer:hop_hover(opts)
+end
+
 --- Move the current infoview to the appropriate spot based on the
 --- current screen dimensions.
 --- Does nothing if there are more than 2 open windows.

--- a/lua/lean/infoview/components.lua
+++ b/lua/lean/infoview/components.lua
@@ -144,6 +144,15 @@ local function code_with_infos(t, sess)
       end
     end
 
+    --FIXME this is essentially a thunked boolean field, adding it as an event
+    --is not exactly, but I'm not sure where to stick it at the moment
+    ---@param kind GoToKind
+    local has_go_to = function(_, kind)
+      local links, err = sess:getGoToLocation(kind, info_with_ctx)
+      if err or #links == 0 then return false end
+      return true
+    end
+
     ---@param kind GoToKind
     local go_to = function(_, kind)
       local links, err = sess:getGoToLocation(kind, info_with_ctx)
@@ -173,6 +182,7 @@ local function code_with_infos(t, sess)
       clear = function(ctx) if info_open then do_reset(ctx) end end,
       go_to = go_to,
       go_to_def = go_to_def,
+      has_go_to = has_go_to,
       go_to_decl = go_to_decl,
       go_to_type = go_to_type,
     }

--- a/lua/lean/init.lua
+++ b/lua/lean/init.lua
@@ -24,6 +24,9 @@ local lean = {
       ['<LocalLeader>w'] = '<Cmd>LeanInfoviewEnableWidgets<CR>';
       ['<LocalLeader>W'] = '<Cmd>LeanInfoviewDisableWidgets<CR>';
       ['<LocalLeader><Tab>'] = '<Cmd>LeanGotoInfoview<CR>';
+      ['<LocalLeader>jj'] = '<Cmd>LeanHopInfoview<CR>';
+      ['<LocalLeader>jd'] = '<Cmd>LeanHopInfoviewDefinition<CR>';
+      ['<LocalLeader>jh'] = '<Cmd>LeanHopInfoviewHover<CR>';
       ['<LocalLeader>s'] = '<Cmd>LeanSorryFill<CR>';
       ['<LocalLeader>t'] = '<Cmd>LeanTryThis<CR>';
       ['<LocalLeader>\\'] = '<Cmd>LeanAbbreviationsReverseLookup<CR>';
@@ -80,6 +83,10 @@ function lean.setup(opts)
     command LeanGotoInfoview :lua require'lean.infoview'.go_to()
 
     command LeanAbbreviationsReverseLookup :lua require'lean.abbreviations'.show_reverse_lookup()
+
+    command LeanHopInfoview :lua require'lean.infoview'.hop()
+    command LeanHopInfoviewDefinition :lua require'lean.infoview'.hop_definition()
+    command LeanHopInfoviewHover :lua require'lean.infoview'.hop_hover()
 
     command LeanSorryFill :lua require'lean.sorry'.fill()
     command LeanTryThis :lua require'lean.trythis'.swap()


### PR DESCRIPTION
Depends on (minor) bug fixes in phaazon/hop.nvim#304. What I've done so far is to map:

- `<localleader>jj` to hop to interactive elements of the infoview
- `<localleader>jd` to use the hop interface to select an element of the infoview that supports go-to-definition (_restricting the hints to such elements_), and go to that definition.
- `<localleader>jh` to use the hop interface to select an interactive element to click (though this is broken at the moment in that the windows don't show up, it's a UI bug I believe)

All of the above operate _from the source code_, so you don't have to context-switch to the infoview window and then go back to the original window. There are a number of additional things I want to do (will make a TODO list later) but I wanted to put this PR up now in case there's any early feedback.

[![asciicast](https://asciinema.org/a/hXoWQQGCYRmDimiD9q3pR7ZMW.svg)](https://asciinema.org/a/hXoWQQGCYRmDimiD9q3pR7ZMW)

^ Sorry if that's a bit inscrutable, I'm trying to figure out how to get my terminal to show keystrokes, but essentially what I did was `<localleader>jj` to go to `some` in the infoview and see its type, and then `<localleader>jd` to go-to-definition of `Option`.

Side note: If you're wondering why I haven't been super active lately, it's because I've been ramping up at a new job where I get to work on Lean full-time! I've settled pretty well at this point and am now finding a healthy balance between work, contributing to neovim, and learning about the Lean 4 implementation with the goal of eventually contributing to its usability aspects. Thanks for your patience!!!