### PR TITLE
Add an option to open the infoview in an entirely new tab.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -313,6 +313,12 @@ Full Configuration & Settings Information
         -- top | bottom
         horizontal_position = "bottom",
 
+        -- Always open the infoview window in a separate tabpage.
+        -- Might be useful if you are using a screen reader and don't want too
+        -- many dynamic updates in the terminal at the same time.
+        -- Note that `height` and `width` will be ignored in this case.
+        separate_tab = false,
+
         -- Show indicators for pin locations when entering an infoview window?
         -- always | never | auto (= only when there are multiple pins)
         indicators = "auto",

--- a/lua/tests/infoview/layout/tab_spec.lua
+++ b/lua/tests/infoview/layout/tab_spec.lua
@@ -1,0 +1,55 @@
+---@brief [[
+--- Tests for infoview layout on a landscape display.
+---@brief ]]
+
+require('tests.helpers')
+local infoview = require('lean.infoview')
+
+require('lean').setup{ infoview = { autoopen = false, separate_tab = true } }
+
+describe('infoview window', function()
+  it('opens in a new tab with the cursor in the Lean window', function(_)
+    assert.is.equal(1, #vim.api.nvim_tabpage_list_wins(0))
+    assert.is.equal(1, #vim.api.nvim_list_tabpages())
+    local lean_window = vim.api.nvim_get_current_win()
+
+    infoview.open()
+
+    assert.is.equal(1, #vim.api.nvim_tabpage_list_wins(0))
+    local tabpages = vim.api.nvim_list_tabpages()
+    assert.is.equal(2, #tabpages)
+    assert.is.equal(1, #vim.api.nvim_tabpage_list_wins(tabpages[2]))
+
+    assert.is.equal(lean_window, vim.api.nvim_get_current_win())
+
+    infoview.close()
+
+    assert.is.equal(1, #vim.api.nvim_tabpage_list_wins(0))
+    assert.is.equal(1, #vim.api.nvim_list_tabpages())
+  end)
+  it('repositioning has no effect', function(_)
+    assert.is.equal(1, #vim.api.nvim_tabpage_list_wins(0))
+    assert.is.equal(1, #vim.api.nvim_list_tabpages())
+    local lean_window = vim.api.nvim_get_current_win()
+
+    infoview.open()
+
+    assert.is.equal(1, #vim.api.nvim_tabpage_list_wins(0))
+    local tabpages = vim.api.nvim_list_tabpages()
+    assert.is.equal(2, #tabpages)
+    assert.is.equal(1, #vim.api.nvim_tabpage_list_wins(tabpages[2]))
+
+    infoview.reposition()
+
+    tabpages = vim.api.nvim_list_tabpages()
+    assert.is.equal(2, #tabpages)
+    assert.is.equal(1, #vim.api.nvim_tabpage_list_wins(tabpages[2]))
+
+    assert.is.equal(lean_window, vim.api.nvim_get_current_win())
+
+    infoview.close()
+
+    assert.is.equal(1, #vim.api.nvim_tabpage_list_wins(0))
+    assert.is.equal(1, #vim.api.nvim_list_tabpages())
+  end)
+end)


### PR DESCRIPTION
This pull request adds an option (infoview.separate_tab: bool) which if set to true will cause the infoview to be opened in a new tabpage rather then in a horizontal or vertical split of the current window.

This is probably not useful for most users since one will not be able to see real time changes in the infoview. But I'm using a [screen reader](https://en.wikipedia.org/wiki/Screen_reader) which speaks all dynamic changes in the terminal immediately. And it sometimes become too much information at the same time when it speaks both changes in the main buffer and the infoview.

A better solution would of course be to make the screen reader smarter so that it can recognize horizontally/verticly split windows and only speak changes in the current window. But that was too complicated for a Sunday evening so I decided to change this pluggin instead.

I'm not an expert in Lua, so feel free to comment or improve my changes.

I would understand if you think the audience for this feature is very limited. It might be that there will only be me and other visually impared people who make use of this feature. But the changes are very small though, so I hope you have no problems to merge it.

