### PR TITLE
Perform ftdetect in pure lua with no plugin call

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,5 +1,7 @@
 globals = {
     "_clean_buffer_count",
     "vim",
+    "lean_nvim_ft_options",
+    "_LEAN3_STANDARD_LIBRARY",
     assert = {fields = {"message"}},
 }

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -2,6 +2,5 @@ globals = {
     "_clean_buffer_count",
     "vim",
     "lean_nvim_ft_options",
-    "_LEAN3_STANDARD_LIBRARY",
     assert = {fields = {"message"}},
 }

--- a/ftdetect/lean.lua
+++ b/ftdetect/lean.lua
@@ -1,0 +1,65 @@
+_LEAN3_STANDARD_LIBRARY = '.*/[^/]*lean[%-]+3.+/lib/'
+local _LEAN3_VERSION_MARKER = '.*lean_version.*".*:3.*'
+local _LEAN4_VERSION_MARKER = '.*lean_version.*".*lean4:.*'
+
+local find_project_root = require('lspconfig.util').root_pattern(
+  'leanpkg.toml',
+  'lakefile.lean',
+  'lean-toolchain'
+)
+
+lean_nvim_ft_options = {
+  default = "lean",
+  nomodifiable = {
+    '.*/src/lean/.*',       -- Lean 4 standard library
+    '.*/lib/lean/src/.*',   -- Lean 4 legacy standard library
+    '.*/lean_packages/.*',  -- Lean 4 dependencies
+    _LEAN3_STANDARD_LIBRARY .. '.*',
+    '/_target/.*/.*.lean'   -- Lean 3 dependencies
+  }
+}
+
+local function detect(filename)
+  if filename:match('^fugitive://.*') then
+    filename = pcall(vim.fn.FugitiveReal, filename)
+  end
+
+  local abspath = vim.fn.fnamemodify(filename, ":p")
+  local filetype = lean_nvim_ft_options.default
+  if abspath:match(_LEAN3_STANDARD_LIBRARY) then
+    filetype = 'lean3'
+  else
+    local project_root = find_project_root(abspath)
+    local succeeded, result
+    if project_root then
+      succeeded, result = pcall(vim.fn.readfile, project_root .. '/lean-toolchain')
+      if succeeded then
+        if result[1]:match('.*:3.*') then filetype = 'lean3'
+        elseif result[1]:match('.*lean4:.*') then filetype = 'lean'
+        end
+      else
+        succeeded, result = pcall(vim.fn.readfile, project_root .. '/leanpkg.toml')
+        if succeeded then
+          for _, line in ipairs(result) do
+            if line:match(_LEAN3_VERSION_MARKER) then
+              filetype = 'lean3'
+              break
+            end
+            if line:match(_LEAN4_VERSION_MARKER) then
+              filetype = 'lean'
+              break
+            end
+          end
+        end
+      end
+    end
+  end
+  vim.opt.filetype = filetype
+end
+
+vim.api.nvim_create_autocmd({'BufRead','BufNewFile'}, {
+    pattern = '*.lean',
+    callback = function(opts)
+      detect(opts.file)
+    end,
+})

--- a/ftdetect/lean.lua
+++ b/ftdetect/lean.lua
@@ -1,4 +1,4 @@
-_LEAN3_STANDARD_LIBRARY = '.*/[^/]*lean[%-]+3.+/lib/'
+local _LEAN3_STANDARD_LIBRARY = '.*/[^/]*lean[%-]+3.+/lib/'
 local _LEAN3_VERSION_MARKER = '.*lean_version.*".*:3.*'
 local _LEAN4_VERSION_MARKER = '.*lean_version.*".*lean4:.*'
 

--- a/ftdetect/lean3.vim
+++ b/ftdetect/lean3.vim
@@ -1,1 +1,0 @@
-autocmd BufRead,BufNewFile *.lean lua require'lean.ft'.detect(vim.fn.expand('<afile>'))

--- a/lua/lean/ft.lua
+++ b/lua/lean/ft.lua
@@ -1,73 +1,15 @@
 local ft = {}
 
-local _LEAN3_STANDARD_LIBRARY = '.*/[^/]*lean[%-]+3.+/lib/'
-local _LEAN3_VERSION_MARKER = '.*lean_version.*".*:3.*'
-local _LEAN4_VERSION_MARKER = '.*lean_version.*".*lean4:.*'
-
-local options = {
-  default = "lean",
-  nomodifiable = {
-    '.*/src/lean/.*',       -- Lean 4 standard library
-    '.*/lib/lean/src/.*',   -- Lean 4 legacy standard library
-    '.*/lean_packages/.*',  -- Lean 4 dependencies
-    _LEAN3_STANDARD_LIBRARY .. '.*',
-    '/_target/.*/.*.lean'   -- Lean 3 dependencies
-  }
-}
-options._DEFAULTS = vim.deepcopy(options)
-
-local find_project_root = require('lspconfig.util').root_pattern(
-  'leanpkg.toml',
-  'lakefile.lean',
-  'lean-toolchain'
-)
-
-function ft.detect(filename)
-  if filename:match('^fugitive://.*') then
-    filename = pcall(vim.fn.FugitiveReal, filename)
-  end
-
-  local abspath = vim.fn.fnamemodify(filename, ":p")
-  local filetype = options.default
-  if abspath:match(_LEAN3_STANDARD_LIBRARY) then
-    filetype = 'lean3'
-  else
-    local project_root = find_project_root(abspath)
-    local succeeded, result
-    if project_root then
-      succeeded, result = pcall(vim.fn.readfile, project_root .. '/lean-toolchain')
-      if succeeded then
-        if result[1]:match('.*:3.*') then filetype = 'lean3'
-        elseif result[1]:match('.*lean4:.*') then filetype = 'lean'
-        end
-      else
-        succeeded, result = pcall(vim.fn.readfile, project_root .. '/leanpkg.toml')
-        if succeeded then
-          for _, line in ipairs(result) do
-            if line:match(_LEAN3_VERSION_MARKER) then
-              filetype = 'lean3'
-              break
-            end
-            if line:match(_LEAN4_VERSION_MARKER) then
-              filetype = 'lean'
-              break
-            end
-          end
-        end
-      end
-    end
-  end
-  vim.opt.filetype = filetype
-end
+lean_nvim_ft_options._DEFAULTS = vim.deepcopy(lean_nvim_ft_options)
 
 function ft.enable(opts)
-  options = vim.tbl_extend("force", options._DEFAULTS, opts)
+  lean_nvim_ft_options= vim.tbl_extend("force", lean_nvim_ft_options._DEFAULTS, opts)
 end
 
 ---Make the given buffer `nomodifiable` if its file name matches a configured list.
 function ft.__maybe_make_nomodifiable(bufnr)
   local name = vim.api.nvim_buf_get_name(bufnr)
-  for _, pattern in ipairs(options.nomodifiable) do
+  for _, pattern in ipairs(lean_nvim_ft_options.nomodifiable) do
     if name:match(pattern) then
       vim.api.nvim_buf_set_option(bufnr, 'modifiable', false)
       return


### PR DESCRIPTION
Summary:
I use the packer package manager which lets one only enable certain
plugins if a filetype related to them is set. In order to get around the
issue that these plugins also may also _set_ those filetypes---packer
installs and loads only the filedetect scripts of the `ft` triggered
plugins. If one attempts to do this for lean.nvim, then the filedetect
script fails as it immediately calls into the lean.nvim plugin which is
yet to be loaded.
Since filedetect scripts can be pure lua in neovim, i have replaced the
`ftdetect/lean3.vim` shim with the standalone `ftdetect/lean.lua`
script.
In order to get around configuration issues, this filedetect script
configures the `ft` configuration global which can be modified by the
plugin itself.

Test Plan:
edited `lua/tests/fixtures/example-lean4-project/Test.lean` and
`lua/tests/fixtures/example-lean3-project/src/foo.lean` and verified
that `set ft?` returned `lean` and `lean3` respectively.

before:
```
$ TEST_FILE=lua/tests/ft_spec.lua ./lua/tests/scripts/run_tests.sh

========================================
Testing: 	lua/tests/ft_spec.lua
Success	||	ft.detect detects nonexisting lean 4 files
Success	||	ft.detect detects nested nonexisting lean 4 files
Success	||	ft.detect detects existing lean 4 files
Success	||	ft.detect detects nested existing lean 4 files
Success	||	ft.detect detects nonexisting lean 3 files
Success	||	ft.detect detects nested nonexisting lean 3 files
Success	||	ft.detect detects existing lean 3 files
Success	||	ft.detect detects nested existing lean 3 files
Fail	||	ft.detect detects lean 4 standard library files
            lua/tests/ft_spec.lua:30: attempt to call field 'wait_for_loading_pins' (a nil value)

            stack traceback:
            	lua/tests/ft_spec.lua:30: in function <lua/tests/ft_spec.lua:24>

Fail	||	ft.detect marks lean 4 standard library files nomodifiable by default
            lua/tests/ft_spec.lua:42: Didn't jump to core Lean!
            Expected to be truthy, but value was:
            (nil)

            stack traceback:
            	lua/tests/ft_spec.lua:42: in function <lua/tests/ft_spec.lua:39>

Success	||	ft.detect does not mark other lean 4 files nomodifiable
Fail	||	ft.detect detects lean 3 standard library files
            lua/tests/ft_spec.lua:57: attempt to call field 'wait_for_line_diagnostics' (a nil value)

            stack traceback:
            	lua/tests/ft_spec.lua:57: in function <lua/tests/ft_spec.lua:51>

Fail	||	ft.detect marks lean 3 standard library files nomodifiable by default
            lua/tests/ft_spec.lua:68: Expected to be truthy, but value was:
            (nil)

            stack traceback:
            	lua/tests/ft_spec.lua:68: in function <lua/tests/ft_spec.lua:66>

Success	||	ft.detect does not mark other lean 3 files nomodifiable

Success: 	10
Failed : 	4
Errors : 	0
========================================
Tests Failed. Exit: 1
```
after:
```
$ TEST_FILE=lua/tests/ft_spec.lua ./lua/tests/scripts/run_tests.sh

========================================
Testing: 	lua/tests/ft_spec.lua
Success	||	ft.detect detects nested nonexisting lean 4 files
Success	||	ft.detect detects existing lean 4 files
Success	||	ft.detect detects nested existing lean 4 files
Success	||	ft.detect detects nonexisting lean 4 files
Success	||	ft.detect detects nested nonexisting lean 3 files
Success	||	ft.detect detects existing lean 3 files
Success	||	ft.detect detects nested existing lean 3 files
Success	||	ft.detect detects nonexisting lean 3 files
Fail	||	ft.detect detects lean 4 standard library files
            lua/tests/ft_spec.lua:30: attempt to call field 'wait_for_loading_pins' (a nil value)

            stack traceback:
            	lua/tests/ft_spec.lua:30: in function <lua/tests/ft_spec.lua:24>

Fail	||	ft.detect marks lean 4 standard library files nomodifiable by default
            lua/tests/ft_spec.lua:42: Didn't jump to core Lean!
            Expected to be truthy, but value was:
            (nil)

            stack traceback:
            	lua/tests/ft_spec.lua:42: in function <lua/tests/ft_spec.lua:39>

Success	||	ft.detect does not mark other lean 4 files nomodifiable
Fail	||	ft.detect detects lean 3 standard library files
            lua/tests/ft_spec.lua:57: attempt to call field 'wait_for_line_diagnostics' (a nil value)

            stack traceback:
            	lua/tests/ft_spec.lua:57: in function <lua/tests/ft_spec.lua:51>

Fail	||	ft.detect marks lean 3 standard library files nomodifiable by default
            lua/tests/ft_spec.lua:68: Expected to be truthy, but value was:
            (nil)

            stack traceback:
            	lua/tests/ft_spec.lua:68: in function <lua/tests/ft_spec.lua:66>

Success	||	ft.detect does not mark other lean 3 files nomodifiable

Success: 	10
Failed : 	4
Errors : 	0
========================================
Tests Failed. Exit: 1
```
same number of tests pass and fail.

Fixes #272