### PR TITLE
Set the cursor to the goal when updating infoview windows.

### DIFF
--- a/lua/lean/infoview.lua
+++ b/lua/lean/infoview.lua
@@ -819,7 +819,11 @@ function Pin:__started_loading()
 end
 
 function Pin:async_update(force)
-  if not force and self.paused then return end
+  -- FIXME: For one, we're guarding here against the infoview being updated
+  --        while it's closed, which if we continued, would end up calling
+  --        render. That doesn't seem right, somewhere that should happen
+  --        higher up than here.
+  if not force and self.paused or not self.__info.__infoview.window then return end
 
   local tick = self.__ticker:lock()
 

--- a/lua/lean/infoview.lua
+++ b/lua/lean/infoview.lua
@@ -590,6 +590,16 @@ function Info:render()
   self.__renderer:render()
   if self.__diff_pin then self.__diff_renderer:render() end
 
+  -- Set the cursor to the line with first goal (just after the marker).
+  for i, line in ipairs(vim.api.nvim_buf_get_lines(self.__renderer.buf, 0, -1, false)) do
+    if line:find("^⊢ ") then
+      vim.api.nvim_win_call(self.__infoview.window,
+        function() vim.cmd.normal(i .. 'z-2l') end
+      )
+      break
+    end
+  end
+
   self.__infoview:__refresh_diff()
   collectgarbage()
 end
@@ -1006,7 +1016,7 @@ end
 
 --- Update pins corresponding to the given URI.
 function infoview.__update_pin_by_uri(uri)
-  if infoview.enabled then
+  if not infoview.enabled then return end
   for _, each in pairs(infoview._by_tabpage) do
     local pins = { each.info.pin }
     vim.list_extend(pins, each.info.pins)
@@ -1015,7 +1025,6 @@ function infoview.__update_pin_by_uri(uri)
         pin:update()
       end
     end
-  end
   end
 end
 

--- a/lua/tests/infoview/contents_spec.lua
+++ b/lua/tests/infoview/contents_spec.lua
@@ -346,6 +346,28 @@ describe('infoview content (auto-)update', function()
     end)
   end)
 
+  for ft, goal in pairs{ lean = '⊢ true = true', lean3 = '⊢ true' } do
+    describe(ft .. ' cursor position', helpers.clean_buffer(ft, '', function()
+      it('is set to the goal line', function()
+        local lines = { 'example ' }
+        for i=1, 100 do
+          table.insert(lines, "(h" .. i .. " : " .. i .. " = " .. i .. ")")
+        end
+        table.insert(lines, ': true :=')
+        table.insert(lines, 'sorry')
+
+        vim.api.nvim_buf_set_lines(0, 0, -1, false, lines)
+        helpers.move_cursor{ to = { #lines, 1 } }
+        helpers.wait_for_loading_pins()
+
+        vim.api.nvim_set_current_win(infoview.get_current_infoview().window)
+
+        assert.are.equal(vim.api.nvim_get_current_line(), goal)
+        assert.are.equal(vim.api.nvim_win_get_cursor(0)[2], #'⊢ ')
+      end)
+    end))
+  end
+
   describe('processing message', helpers.clean_buffer('lean', '#eval IO.sleep 5000', function()
     it('is shown while a file is processing', function()
       local uri = vim.uri_from_fname(vim.api.nvim_buf_get_name(0))


### PR DESCRIPTION
The main motivation for this is that it makes the goal visible when the infoview is full of many lines (e.g. there are many hypotheses). In particular this happens a lot on vertical displays with horizontal infoviews (that don't offer many lines).

Closes: #240