### PR TITLE
fix: lazy require other dependencies

### DIFF
--- a/ftdetect/lean.lua
+++ b/ftdetect/lean.lua
@@ -2,18 +2,12 @@ local _LEAN3_STANDARD_LIBRARY = '.*/[^/]*lean[%-]+3.+/lib/'
 local _LEAN3_VERSION_MARKER = '.*lean_version.*".*:3.*'
 local _LEAN4_VERSION_MARKER = '.*lean_version.*".*lean4:.*'
 
-local find_project_root = require('lspconfig.util').root_pattern(
-  'leanpkg.toml',
-  'lakefile.lean',
-  'lean-toolchain'
-)
-
 local function detect(filename)
-  if filename:match('^fugitive://.*') then
+  if filename:match '^fugitive://.*' then
     filename = pcall(vim.fn.FugitiveReal, filename)
   end
 
-  local abspath = vim.fn.fnamemodify(filename, ":p")
+  local abspath = vim.fn.fnamemodify(filename, ':p')
   local filetype = lean_nvim_default_filetype
   if not filetype then
     filetype = 'lean'
@@ -22,13 +16,17 @@ local function detect(filename)
   if abspath:match(_LEAN3_STANDARD_LIBRARY) then
     filetype = 'lean3'
   else
+    local find_project_root =
+      require('lspconfig.util').root_pattern('leanpkg.toml', 'lakefile.lean', 'lean-toolchain')
     local project_root = find_project_root(abspath)
     local succeeded, result
     if project_root then
       succeeded, result = pcall(vim.fn.readfile, project_root .. '/lean-toolchain')
       if succeeded then
-        if result[1]:match('.*:3.*') then filetype = 'lean3'
-        elseif result[1]:match('.*lean4:.*') then filetype = 'lean'
+        if result[1]:match '.*:3.*' then
+          filetype = 'lean3'
+        elseif result[1]:match '.*lean4:.*' then
+          filetype = 'lean'
         end
       else
         succeeded, result = pcall(vim.fn.readfile, project_root .. '/leanpkg.toml')
@@ -50,9 +48,9 @@ local function detect(filename)
   vim.opt.filetype = filetype
 end
 
-vim.api.nvim_create_autocmd({'BufRead','BufNewFile'}, {
-    pattern = '*.lean',
-    callback = function(opts)
-      detect(opts.file)
-    end,
+vim.api.nvim_create_autocmd({ 'BufRead', 'BufNewFile' }, {
+  pattern = '*.lean',
+  callback = function(opts)
+    detect(opts.file)
+  end,
 })


### PR DESCRIPTION
I'm using `lazy.nvim` and I've just began learning `lean`. However, even when I'm editing projects in other languages, some annoying errors popped out from this plugin.

```text
Failed to run `config` for lspsaga.nvim                                                                                                                                                       
/home/cl/.config/nvim/lua/modules/utils/init.lua:39: attempt to index field 'colors_name' (a nil value)                                                                                       
# stacktrace:                                                                                                                                                                                 
  - ~/.config/nvim/lua/modules/utils/init.lua:39 _in_ **get_palette**                                                                                                                         
  - ~/.config/nvim/lua/modules/utils/init.lua:150 _in_ **gen_lspkind_hl**                                                                                                                     
  - ~/.config/nvim/lua/modules/configs/completion/lspsaga.lua:2 _in_ **config**                                                                                                               
  - /lean.nvim/ftdetect/lean.lua:5                                                                                                                                                            
  - vim/_editor.lua:0 _in_ **cmd**                                                                                                                                                            
  - ~/.config/nvim/lua/core/pack.lua:128 _in_ **load_lazy**                                                                                                                                   
  - ~/.config/nvim/lua/core/pack.lua:131                                                                                                                                                      
  - ~/.config/nvim/lua/core/init.lua:166 _in_ **load_core**                                                                                                                                   
  - ~/.config/nvim/lua/core/init.lua:174                                                                                                                                                      
  - ~/.config/nvim/init.lua:2  
```

As is mentioned in its [README](https://github.com/folke/lazy.nvim#%EF%B8%8F-startup-sequence), `Lazy.nvim` will automatically run `init` for all plugins, regardless of their laziness (by `lazyness` I mean lazy-loading). And unfortunately, the plugin has required other plugins in its `ftdetect` script.

It's actually an easy one-line fix, the function to call will be lazily loaded. The file is reformatted.