### PR TITLE
fix typo in calc snippet

### DIFF
--- a/snippets/lean.json
+++ b/snippets/lean.json
@@ -3,7 +3,7 @@
     "prefix": "calc",
     "body": [
       "calc ${1:start} = ${2:first} := by ${3:sorry}",
-      "  _ = ${4:second} : by ${5:sorry}"
+      "  _ = ${4:second} := by ${5:sorry}"
     ],
     "description": "Scaffolding for authoring `calc` blocks"
   },


### PR DESCRIPTION
missing `=` in `:= by sorry`