### PR TITLE
Tweak the Loogle search implementation slightly in a few ways.

### DIFF
--- a/lua/lean/loogle.lua
+++ b/lua/lean/loogle.lua
@@ -1,0 +1,48 @@
+local curl = require('plenary.curl')
+
+local loogle = {}
+
+---@class LoogleResult
+---@field name string
+---@field type string
+---@field module string
+---@field doc string
+
+---Search Loogle for the given type.
+---@param type string The type pattern to look for.
+---@return LoogleResult[]? results Loogle hits in the JSON API format
+---@return string? err An error message from Loogle, in which case no results are returned
+function loogle.search(type)
+  local res = curl.get{
+    url = 'https://loogle.lean-lang.org/json',
+    query = { q = type },
+    headers = { ['User-Agent'] = 'lean.nvim' },
+    accept = 'application/json',
+  }
+
+  if res.status ~= 200 then
+    error('Loogle returned status code: ' .. res.status)
+  end
+
+  local body = vim.fn.json_decode(res.body)
+  if body.error then
+    return nil, body.error
+  end
+
+  return body.hits
+end
+
+---Create a minimal Lean file out of the given result.
+---@param result LoogleResult the result to template out
+---@return string[] lines a list-like table containing a Lean file template
+function loogle.template(result)
+  local lines = {
+    'import ' .. result.module,
+    '',
+  }
+  local with_name = result.name .. ' : ' .. result.type
+  vim.list_extend(lines, vim.split(with_name:gsub('\n%s*', '\n  '), '\n'))
+  return lines
+end
+
+return loogle

--- a/lua/telescope/_extensions/loogle/loogle_search.lua
+++ b/lua/telescope/_extensions/loogle/loogle_search.lua
@@ -1,79 +1,43 @@
-local pickers = require('telescope.pickers')
-local actions_state = require 'telescope.actions.state'
-local finders = require('telescope.finders')
-local conf = require('telescope.config').values
 local actions = require('telescope.actions')
+local actions_state = require('telescope.actions.state')
+local config = require('telescope.config')
+local finders = require('telescope.finders')
+local pickers = require('telescope.pickers')
 local previewers = require('telescope.previewers')
 
-local curl = require 'plenary.curl'
+local loogle = require('lean.loogle')
 
 local M = {}
 
-
---- Ask for a type pattern in the UI
---- @return string?, string? type The first value is a type. The second a potential error.
-M.ask_for_type = function()
-  local type = ''
-  local on_confirm = function(input) type = input end
-  vim.ui.input({prompt = 'Enter Loogle type pattern: '}, on_confirm)
-  if type == nil or type == '' then
-    return nil, 'Type was empty'
-  end
-  return type, nil
-end
-
---- Ask for a type pattern in the UI
---- @param type string The type pattern to look for.
---- @return table?, string? hits The first value is the hits in the Loogle JSON API format. The second a potential error
-M.look_for_type = function(type)
-  local res = curl.get {
-    url = 'https://loogle.lean-lang.org/json',
-    query = { q = type },
-    headers = {
-     ['User-Agent'] = 'lean.nvim'
-    },
-    accept = 'application/json',
-  }
-
-  if res.status ~= 200 then
-    return nil, 'Loogle returned status code: ' .. res.status
-  end
-
-  local body = vim.fn.json_decode(res.body)
-  if body.error then
-    return nil, 'Loogle returned error: ' .. body.error
-  end
-
-  if body.count == 0 then
-    return nil, 'Loogle found no matches'
-  end
-
-  return body.hits, nil
-end
+---@class LoogleTelescopeEntry
+---@field value LoogleResult
 
 --- Use telescope to provide a Loogle API based type search
 --- @param telescope_opts table Options for the telescope framework
 M.find = function(telescope_opts)
   telescope_opts = vim.tbl_extend('keep', telescope_opts or {}, {})
 
-  local type, results, err
+  local type
+  vim.ui.input(
+    { prompt = 'Enter a type pattern to search on Loogle: ' },
+    function(choice) type = choice end
+  )
+  if not type or type == '' then return end
 
-  type, err = M.ask_for_type()
+  local results, err = loogle.search(type)
   if err then
-    vim.api.nvim_notify(err, vim.log.levels.ERROR, {})
+    vim.notify(('Loogle error: %s'):format(err), vim.log.levels.ERROR, {})
     return
-  end
-
-  results, err = M.look_for_type(type)
-  if err then
-    vim.api.nvim_notify(err, vim.log.levels.ERROR, {})
+  elseif vim.tbl_isempty(results or {}) then
+    vim.notify(('No Loogle results for %q'):format(type), vim.log.levels.ERROR, {})
     return
   end
 
   pickers.new(telescope_opts, {
     prompt_title = 'Loogle Search Filter',
-    finder = finders.new_table {
+    finder = finders.new_table{
       results = results,
+      ---@param entry LoogleResult
       entry_maker = function(entry)
         return {
           value = entry,
@@ -82,25 +46,23 @@ M.find = function(telescope_opts)
         }
       end
     },
-    sorter = conf.generic_sorter(telescope_opts),
-    previewer = previewers.new_buffer_previewer({
+    sorter = config.values.generic_sorter(telescope_opts),
+
+    previewer = previewers.new_buffer_previewer{
+      ---@param entry LoogleTelescopeEntry
       define_preview = function(self, entry)
-        local d = entry.value
-
-        local output = { 'import ' .. d.module}
-        table.insert(output, '')
-
-        table.insert(output, d.name .. ' : ' .. d.type)
-
-        require('telescope.previewers.utils').highlighter(self.state.bufnr, 'lean')
-        vim.api.nvim_buf_set_lines(self.state.bufnr, 0, -1, false, output)
+        local bufnr = self.state.bufnr
+        local lines = loogle.template(entry.value)
+        require('telescope.previewers.utils').highlighter(bufnr, 'lean')
+        vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
       end
-    }),
+    },
     attach_mappings = function(prompt_bufnr, _)
       actions.select_default:replace(function()
         actions.close(prompt_bufnr)
+        ---@type LoogleTelescopeEntry
         local selection = actions_state.get_selected_entry()
-        vim.api.nvim_put({ selection.value.name }, '', false, true)
+        vim.api.nvim_put({ selection.value.name }, 'c', true, true)
       end)
       return true
     end,


### PR DESCRIPTION
  * Fix Loogle sometimes returning responses with newlines, breaking nvim_buf_set_lines which wants none -- e.g. Complex.cos_add_mul_I returns a type with newlines in it. What we do now is split, then indent any newlines so the preview file looks "reasonableish"
  * Make the result be `put` charwise, so that e.g. #check <loogle here> will never insert extra lines
  * Make it usable outside of telescope via `require'lean.loogle'.search()`, which simply returns results
  * Add some more typing for Loogle API responses
  * Use Lua errors (exceptions) in a place or two to avoid some manual error checking

There's probably a few small other things that can be tidied.