### PR TITLE
chore: adapt to changes in client fields for `vim.lsp.client`

### DIFF
--- a/lua/lean/lsp.lua
+++ b/lua/lean/lsp.lua
@@ -112,7 +112,7 @@ function lsp.restart_file(bufnr)
     textDocument = {
       version = 0,
       uri = uri,
-      languageId = client.config.get_language_id(bufnr, vim.bo.filetype),
+      languageId = client.get_language_id(bufnr, vim.bo.filetype),
       text = util.buf_get_full_text(bufnr),
     },
   })


### PR DESCRIPTION
`get_language_id` has moved out from under `config` and up a level, see https://neovim.io/doc/user/lsp.html#lsp-client.
