### PR TITLE
feat(infoview): more buffer options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+TODO*
+
 leanpkg.path
 *.olean
 .lake/

--- a/ftplugin/leaninfo.lua
+++ b/ftplugin/leaninfo.lua
@@ -1,9 +1,14 @@
 vim.bo.modifiable = false
 vim.bo.undolevels = -1
 vim.wo.cursorline = false
+vim.wo.cursorcolumn = false
+vim.wo.colorcolumn = ""
 vim.wo.number = false
 vim.wo.relativenumber = false
 vim.wo.spell = false
 vim.wo.winfixheight = true
 vim.wo.winfixwidth = true
 vim.wo.wrap = true
+if vim.fn.exists('&winfixbuf') > 0 then
+  vim.wo.winfixbuf = true
+end

--- a/lua/lean/abbreviations.lua
+++ b/lua/lean/abbreviations.lua
@@ -68,7 +68,7 @@ function abbreviations.show_reverse_lookup()
       end
     end
   end
-  vim.lsp.util.open_floating_preview(lines)
+  vim.lsp.util.open_floating_preview(lines, 'markdown')
 end
 
 local abbr_mark_ns = vim.api.nvim_create_namespace 'lean.abbreviations'
@@ -89,8 +89,9 @@ local function insert_char_pre()
   local char = vim.api.nvim_get_vvar 'char'
 
   if abbreviations.abbr_mark then
-    if vim.tbl_contains({ '{', '}', '(', ')', ' ' }, char) then
-      return vim.schedule(abbreviations.convert)
+    if char == ' ' then
+      vim.schedule(abbreviations.convert)
+      return
     end
   end
 
@@ -108,7 +109,7 @@ local function insert_char_pre()
           col1,
           { end_line = row2, end_col = col2 }
         )
-        return vim.schedule(function()
+        vim.schedule(function()
           row1, col1, row2, col2 = get_extmark_range(abbr_mark_ns, tmp_extmark)
           if not row1 then
             return
@@ -116,6 +117,7 @@ local function insert_char_pre()
           vim.api.nvim_buf_del_extmark(0, abbr_mark_ns, tmp_extmark)
           vim.api.nvim_buf_set_text(0, row1, col1, row2, col2, {})
         end)
+        return
       end
     end
   end

--- a/lua/lean/lsp.lua
+++ b/lua/lean/lsp.lua
@@ -112,7 +112,7 @@ function lsp.restart_file(bufnr)
     textDocument = {
       version = 0,
       uri = uri,
-      languageId = client.config.get_language_id(bufnr, vim.bo.filetype),
+      languageId = client.get_language_id(bufnr, vim.bo.filetype),
       text = util.buf_get_full_text(bufnr),
     },
   })

--- a/lua/tests/infoview/pin_spec.lua
+++ b/lua/tests/infoview/pin_spec.lua
@@ -159,156 +159,169 @@ describe(
         ))
       end)
 
-      describe('edits around pin', function()
-        infoview.clear_pins()
-        helpers.move_cursor { to = { 4, 12 } }
-        infoview.add_pin()
+      describe('edits around pin',
+        helpers.clean_buffer(
+          [[
+            theorem has_tactic_goal : p ∨ q → q ∨ p := by
+              intro h
+              cases h with
+              | inl h1 =>
+                apply Or.inr
+                exact h1
+              | inr h2 =>
+                apply Or.inl
+                assumption
+          ]],
+          function()
+            infoview.clear_pins()
+            helpers.move_cursor { to = { 4, 12 } }
+            infoview.add_pin()
 
-        it('moves pin when lines are added above it', function()
-          vim.api.nvim_buf_set_lines(0, 0, 0, true, { 'theorem foo : 2 = 2 := rfl', '' })
-          helpers.move_cursor { to = { 1, 24 } }
-          assert.infoview_contents.are(string.format(
-            [[
-              ▶ expected type (1:24-1:27)
-              ⊢ 2 = 2
+            it('moves pin when lines are added above it', function()
+              vim.api.nvim_buf_set_lines(0, 0, 0, true, { 'theorem foo : 2 = 2 := rfl', '' })
+              helpers.move_cursor { to = { 1, 24 } }
+              assert.infoview_contents.are(string.format(
+                [[
+                  ▶ expected type (1:24-1:27)
+                  ⊢ 2 = 2
 
-              -- %s at 6:11
-              case inl
-              p q : Prop
-              h1 : p
-              ⊢ q ∨ p
-            ]],
-            vim.api.nvim_buf_get_name(0)
-          ))
-        end)
+                  -- %s at 6:11
+                  case inl
+                  p q : Prop
+                  h1 : p
+                  ⊢ q ∨ p
+                ]],
+                vim.api.nvim_buf_get_name(0)
+              ))
+            end)
 
-        it('moves pin when lines are removed above it', function()
-          assert.infoview_contents.are(string.format(
-            [[
-              ▶ expected type (1:24-1:27)
-              ⊢ 2 = 2
+            it('moves pin when lines are removed above it', function()
+              assert.infoview_contents.are(string.format(
+                [[
+                  ▶ expected type (1:24-1:27)
+                  ⊢ 2 = 2
 
-              -- %s at 6:11
-              case inl
-              p q : Prop
-              h1 : p
-              ⊢ q ∨ p
-            ]],
-            vim.api.nvim_buf_get_name(0)
-          ))
+                  -- %s at 6:11
+                  case inl
+                  p q : Prop
+                  h1 : p
+                  ⊢ q ∨ p
+                ]],
+                vim.api.nvim_buf_get_name(0)
+              ))
 
-          helpers.move_cursor { to = { 3, 50 } }
-          vim.api.nvim_buf_set_lines(0, 0, 2, true, {})
+              helpers.move_cursor { to = { 3, 50 } }
+              vim.api.nvim_buf_set_lines(0, 0, 2, true, {})
 
-          assert.infoview_contents.are(string.format(
-            [[
-              p q : Prop
-              ⊢ p ∨ q → q ∨ p
+              assert.infoview_contents.are(string.format(
+                [[
+                  p q : Prop
+                  ⊢ p ∨ q → q ∨ p
 
-              -- %s at 4:11
-              case inl
-              p q : Prop
-              h1 : p
-              ⊢ q ∨ p
-            ]],
-            vim.api.nvim_buf_get_name(0)
-          ))
-        end)
+                  -- %s at 4:11
+                  case inl
+                  p q : Prop
+                  h1 : p
+                  ⊢ q ∨ p
+                ]],
+                vim.api.nvim_buf_get_name(0)
+              ))
+            end)
 
-        it('does not move pin when lines are added or removed below it', function()
-          assert.infoview_contents.are(string.format(
-            [[
-              p q : Prop
-              ⊢ p ∨ q → q ∨ p
+            it('does not move pin when lines are added or removed below it', function()
+              assert.infoview_contents.are(string.format(
+                [[
+                  p q : Prop
+                  ⊢ p ∨ q → q ∨ p
 
-              -- %s at 4:11
-              case inl
-              p q : Prop
-              h1 : p
-              ⊢ q ∨ p
-            ]],
-            vim.api.nvim_buf_get_name(0)
-          ))
+                  -- %s at 4:11
+                  case inl
+                  p q : Prop
+                  h1 : p
+                  ⊢ q ∨ p
+                ]],
+                vim.api.nvim_buf_get_name(0)
+              ))
 
-          vim.api.nvim_buf_set_lines(0, -1, -1, true, { '', 'theorem foo : 2 = 2 := rfl' })
+              vim.api.nvim_buf_set_lines(0, -1, -1, true, { '', 'theorem foo : 2 = 2 := rfl' })
 
-          helpers.move_cursor { to = { 11, 24 } }
-          assert.infoview_contents.are(string.format(
-            [[
-              ▶ expected type (11:24-11:27)
-              ⊢ 2 = 2
+              helpers.move_cursor { to = { 11, 24 } }
+              assert.infoview_contents.are(string.format(
+                [[
+                  ▶ expected type (11:24-11:27)
+                  ⊢ 2 = 2
 
-              -- %s at 4:11
-              case inl
-              p q : Prop
-              h1 : p
-              ⊢ q ∨ p
-            ]],
-            vim.api.nvim_buf_get_name(0)
-          ))
+                  -- %s at 4:11
+                  case inl
+                  p q : Prop
+                  h1 : p
+                  ⊢ q ∨ p
+                ]],
+                vim.api.nvim_buf_get_name(0)
+              ))
 
-          vim.api.nvim_buf_set_lines(0, 9, 11, true, {})
+              vim.api.nvim_buf_set_lines(0, 9, 11, true, {})
 
-          helpers.move_cursor { to = { 1, 50 } }
-          assert.infoview_contents.are(string.format(
-            [[
-              p q : Prop
-              ⊢ p ∨ q → q ∨ p
+              helpers.move_cursor { to = { 1, 50 } }
+              assert.infoview_contents.are(string.format(
+                [[
+                  p q : Prop
+                  ⊢ p ∨ q → q ∨ p
 
-              -- %s at 4:11
-              case inl
-              p q : Prop
-              h1 : p
-              ⊢ q ∨ p
-            ]],
-            vim.api.nvim_buf_get_name(0)
-          ))
-        end)
+                  -- %s at 4:11
+                  case inl
+                  p q : Prop
+                  h1 : p
+                  ⊢ q ∨ p
+                ]],
+                vim.api.nvim_buf_get_name(0)
+              ))
+            end)
 
-        it('moves pin when changes are made on its line before its column', function()
-          helpers.move_cursor { to = { 4, 7 } }
-          vim.cmd.normal 'cl37' -- h1 -> h37
-          helpers.move_cursor { to = { 1, 50 } }
-          assert.infoview_contents.are(string.format(
-            [[
-              p q : Prop
-              ⊢ p ∨ q → q ∨ p
+            it('moves pin when changes are made on its line before its column', function()
+              helpers.move_cursor { to = { 4, 7 } }
+              vim.cmd.normal 'cl37' -- h1 -> h37
+              helpers.move_cursor { to = { 1, 50 } }
+              assert.infoview_contents.are(string.format(
+                [[
+                  p q : Prop
+                  ⊢ p ∨ q → q ∨ p
 
-              -- %s at 4:12
-              case inl
-              p q : Prop
-              h37 : p
-              ⊢ q ∨ p
-            ]],
-            vim.api.nvim_buf_get_name(0)
-          ))
-        end)
+                  -- %s at 4:12
+                  case inl
+                  p q : Prop
+                  h37 : p
+                  ⊢ q ∨ p
+                ]],
+                vim.api.nvim_buf_get_name(0)
+              ))
+            end)
 
-        it('does not move pin when changes are made on its line after its column', function()
-          helpers.move_cursor { to = { 4, 13 } }
-          vim.cmd.normal 'a    '
-          helpers.move_cursor { to = { 1, 50 } }
-          assert.infoview_contents.are(string.format(
-            [[
-              p q : Prop
-              ⊢ p ∨ q → q ∨ p
+            it('does not move pin when changes are made on its line after its column', function()
+              helpers.move_cursor { to = { 4, 13 } }
+              vim.cmd.normal 'a    '
+              helpers.move_cursor { to = { 1, 50 } }
+              assert.infoview_contents.are(string.format(
+                [[
+                  p q : Prop
+                  ⊢ p ∨ q → q ∨ p
 
-              -- %s at 4:12
-              case inl
-              p q : Prop
-              h37 : p
-              ⊢ q ∨ p
-            ]],
-            vim.api.nvim_buf_get_name(0)
-          ))
+                  -- %s at 4:12
+                  case inl
+                  p q : Prop
+                  h37 : p
+                  ⊢ q ∨ p
+                ]],
+                vim.api.nvim_buf_get_name(0)
+              ))
 
-          infoview.clear_pins()
-          assert.infoview_contents.are [[
-            p q : Prop
-            ⊢ p ∨ q → q ∨ p
-          ]]
-        end)
-      end)
+              infoview.clear_pins()
+              assert.infoview_contents.are [[
+                p q : Prop
+                ⊢ p ∨ q → q ∨ p
+              ]]
+            end)
+        end))
 
       describe('diff pins', function()
         local lean_window


### PR DESCRIPTION
Sets `nocursorcolumn`, `colorcolumn=""`, and `winfixbuf` (when available).
`'nocursorcolumn'` and `'colorcolumn'` are to prevent global options from
affecting the infoview buffer (the former is for consistency with
`'nocursorline'`, which is already present). `'winfixbuf'` is a new feature
in Neovim 0.10 that restricts the window to that particular buffer.

Closes #332.