### PR TITLE
fix(abbr): don't stop abbr on `{}()`

### DIFF
--- a/lua/lean/abbreviations.lua
+++ b/lua/lean/abbreviations.lua
@@ -68,7 +68,7 @@ function abbreviations.show_reverse_lookup()
       end
     end
   end
-  vim.lsp.util.open_floating_preview(lines)
+  vim.lsp.util.open_floating_preview(lines, 'markdown')
 end
 
 local abbr_mark_ns = vim.api.nvim_create_namespace 'lean.abbreviations'
@@ -89,8 +89,9 @@ local function insert_char_pre()
   local char = vim.api.nvim_get_vvar 'char'
 
   if abbreviations.abbr_mark then
-    if vim.tbl_contains({ '{', '}', '(', ')', ' ' }, char) then
-      return vim.schedule(abbreviations.convert)
+    if char == ' ' then
+      vim.schedule(abbreviations.convert)
+      return
     end
   end
 
@@ -108,7 +109,7 @@ local function insert_char_pre()
           col1,
           { end_line = row2, end_col = col2 }
         )
-        return vim.schedule(function()
+        vim.schedule(function()
           row1, col1, row2, col2 = get_extmark_range(abbr_mark_ns, tmp_extmark)
           if not row1 then
             return
@@ -116,6 +117,7 @@ local function insert_char_pre()
           vim.api.nvim_buf_del_extmark(0, abbr_mark_ns, tmp_extmark)
           vim.api.nvim_buf_set_text(0, row1, col1, row2, col2, {})
         end)
+        return
       end
     end
   end


### PR DESCRIPTION
Since open braces/parentheses are almost always preceded by spaces, and
close braces/parentheses are almost always succeeded by spaces, there's
no real advantage to immediately converting an abbreviation when these
are seen. Moreover, this meant that the abbreviations `\{{` and `\}}`
were impossible to use (and we had to resort to `\c[` and `\c]`
instead). Overall, this change feels like a net positive (and users can
still override by just pressing `<Tab>` anyways.

This also makes a couple of minor changes with no noticeable effect
- Passing in `{syntax}` to `vim.lsp.util.open_floating_preview()`, which is
  documented as a mandatory parameter.
- Not returning `vim.schedule()` calls in `insert_char_pre()`, since
  returning truthy values from an autocmd callback causes the autocmd to
  be deleted. `vim.schedule()` is documented as always returning `nil`, so
  this doesn't really matter, but this is clearer.
