### PR TITLE
specify file extension for abbreviations

### DIFF
--- a/lua/lean/abbreviations.lua
+++ b/lua/lean/abbreviations.lua
@@ -256,7 +256,7 @@ function abbreviations.convert()
   vim.api.nvim_win_set_cursor(0, { row1 + 1, col1 + new_cursor_col_shift })
 end
 
-function abbreviations.enable(opts)
+function abbreviations.enable(pattern, opts)
   abbreviations.leader = opts.leader or '\\'
 
   abbreviations.abbreviations = abbreviations.load()
@@ -264,7 +264,7 @@ function abbreviations.enable(opts)
     abbreviations.abbreviations[from] = to
   end
 
-  local augroup = vim.api.nvim_create_augroup('LeanAbbreviations', {})
+  local augroup = vim.api.nvim_create_augroup('LeanAbbreviations' .. pattern, {})
   for event, callback in pairs {
     InsertCharPre = insert_char_pre,
     InsertLeave = abbreviations.convert,
@@ -272,10 +272,11 @@ function abbreviations.enable(opts)
   } do
     vim.api.nvim_create_autocmd(event, {
       group = augroup,
-      pattern = { '*.lean' },
+      pattern = pattern,
       callback = callback,
     })
   end
+
   vim.api.nvim_create_autocmd('CmdwinEnter', { group = augroup, callback = cmdwin_enter })
   vim.api.nvim_create_autocmd('CmdwinLeave', { group = augroup, callback = cmdwin_leave })
   vim.cmd [[hi def leanAbbreviationMark cterm=underline gui=underline guisp=Gray]]

--- a/lua/lean/init.lua
+++ b/lua/lean/init.lua
@@ -38,7 +38,7 @@ function lean.setup(opts)
 
   opts.abbreviations = opts.abbreviations or {}
   if opts.abbreviations.enable ~= false then
-    require('lean.abbreviations').enable(opts.abbreviations)
+    require('lean.abbreviations').enable('*.lean', opts.abbreviations)
   end
 
   opts.infoview = opts.infoview or {}


### PR DESCRIPTION
This is my attempt to implement what was [suggested on Zulip](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/lean.2Envim/near/456570614) for allowing the lean.nvim abbreviations for other file extensions.

The usage here would be that you call something like `require('lean.abbreviations').enable('*.tex', {})` to add a file extension. As I've not ever written much Lua or nvim plugins previously I'm not sure at all about what is considered idiomatic, so please give feedback as needed!