### PR TITLE
Add test for LeanRestartFile mapping

### DIFF
--- a/spec/mappings_spec.lua
+++ b/spec/mappings_spec.lua
@@ -34,6 +34,17 @@ describe('mappings', function()
         end
       end)
     )
+
+    it(
+      'can restart file',
+      clean_buffer(function()
+        local restart_file_lhs = '<LocalLeader>r'
+        local restart_file_rhs = '<Cmd>LeanRestartFile<CR>'
+
+        assert.is.not_nil(restart_file_rhs)
+        assert.is.same(restart_file_rhs, vim.fn.maparg(restart_file_lhs, 'n'))
+      end)
+    )
   end)
 
   describe('for infoviews', function()


### PR DESCRIPTION
This is the test for #357 . It passes in the sense that

```
just retest spec/mappings_spec.lua
```

returns 0, and I can manage to fail it too.

But it's mostly a dummy test, checking the key mapping is set, but I don't really know how to check if it can restart file.

So, feel free to close without merging.

Also, I can't pass all existing tests locally, some of them are failing without modifications, the log file is attached.

[just-test.log](https://github.com/user-attachments/files/17486662/just-test.log)
