### PR TITLE
fix(keymap): not shadow keymap desc so make blink.cmp happy

### DIFF
--- a/lua/lean/abbreviations.lua
+++ b/lua/lean/abbreviations.lua
@@ -164,6 +164,7 @@ local function insert_char_pre()
             expr = imap.expr,
             unique = imap.unique,
             callback = imap.callback,
+            desc = imap.desc,
           })
         end
       end


### PR DESCRIPTION
fix Saghen/blink.cmp#441

Currently blink.cmp use `desc` to identify blink.cmp keymap, so shadow `decs` option in  lean.nvim would make stack overflow in blink.cmp side.

I think this should mainly be handled for blink.cmp, but restore `desc` option after cleanup by lean.nvim seems also a reasonable default.