### PR TITLE
Add config for goals accomplished and no goals

### DIFF
--- a/lsp/leanls.lua
+++ b/lsp/leanls.lua
@@ -217,15 +217,16 @@ return {
   },
   on_init = function(_, response)
     local version = response.serverInfo.version
+    local markers = CONFIG.goal_markers
     ---Lean 4.19 introduces silent diagnostics, which we use to differentiate
-    ---between "No goals." and "Goals accomplished. For older versions, we
+    ---between "No goals." and "Goals accomplished". For older versions, we
     ---always say the latter (which is consistent with `lean.nvim`'s historic
     ---behavior, albeit not with VSCode's).
     ---
     ---Technically this being a global is wrong, and will mean we start
     ---showing the wrong message if someone opens an older Lean buffer in the
     ---same session as a newer one...
-    vim.g.lean_no_goals_message = vim.version.ge(version, '0.3.0') and 'No goals.'
-      or 'Goals accomplished 🎉'
+    vim.g.lean_no_goals_message = vim.version.ge(version, '0.3.0') and markers.no_goals
+      or markers.goals_accomplished
   end,
 }

--- a/lua/lean/config.lua
+++ b/lua/lean/config.lua
@@ -42,6 +42,8 @@
 ---@class lean.goal_markers.Config
 ---@field unsolved? string a character which will be placed on buffer lines where there is an unsolved goal
 ---@field accomplished? string a character which will be placed in the sign column of successful proofs
+---@field goals_accomplished? string a string to display in the infoview when the proof is successful
+---@field no_goals? string a string to display in the infoview when there are no active goals
 
 ---@class lean.infoview.Config
 ---@field mappings? { [string]: ElementEvent }
@@ -95,6 +97,8 @@ local DEFAULTS = {
   goal_markers = {
     unsolved = ' ⚒ ',
     accomplished = '🎉',
+    goals_accomplished = 'Goals accomplished 🎉',
+    no_goals = 'No goals.',
   },
 
   ---@type Log

--- a/lua/lean/infoview/components.lua
+++ b/lua/lean/infoview/components.lua
@@ -88,10 +88,11 @@ function components.goal_at(params, sess, use_widgets)
   end
 
   local title
+  local markers = config().goal_markers
   if lsp.goals_accomplished_at(params) then
-    title = 'Goals accomplished 🎉'
+    title = markers.goals_accomplished
   elseif goal and #goal == 0 then -- between goals / Lean <4.19 with no markers
-    title = vim.g.lean_no_goals_message or 'No goals.'
+    title = vim.g.lean_no_goals_message or markers.no_goals
   else
     return children, err
   end


### PR DESCRIPTION
Purely vanity change, feel free to close if you think it's unnecessary!

Inspired by the goal completion message

> After using [`rfl`](https://lean-lang.org/doc/reference/latest//Tactic-Proofs/Tactic-Reference/#rfl), the resulting state is:
> All goals completed! 🐙

in the [lean language reference](https://lean-lang.org/doc/reference/latest//Introduction/#code-samples). I was curious where this came from, and bisected it to [leanprover/verso](https://github.com/leanprover/verso/blob/41b85d429fcdb33349115edc063078dd98ee7c0b/src/verso-blog/Verso/Genre/Blog/Template.lean#L138) ([41b85d4](https://github.com/leanprover/verso/commit/41b85d429fcdb33349115edc063078dd98ee7c0b)).

Technically the message for no goals can already be configured with `vim.g.lean_no_goals_message`, but this is an implementation detail and must be done with an autocmd like the following as the lsp itself sets it on initialization.

```lua
vim.api.nvim_create_autocmd("LspAttach", {
    group = "vimrc",
    pattern = { "*.lean" },
    callback = function()
        vim.g.lean_no_goals_message = "No goals!"
    end,
})
```