### PR TITLE
Fix deprecated use of lspconfig

### DIFF
--- a/lua/lean/lsp.lua
+++ b/lua/lean/lsp.lua
@@ -225,7 +225,8 @@ function lsp.enable(opts)
         or 'Goals accomplished 🎉'
     end,
   })
-  require('lspconfig').leanls.setup(opts)
+  vim.lsp.enable 'leanls'
+  vim.lsp.config('leanls', opts)
 end
 
 ---Restart the Lean server for an open Lean 4 file.


### PR DESCRIPTION
I saw that `leanls.lua` is not yet in the new `lsp/` directory in the `lspconfig` plugin. I wrote the PR [4084](https://github.com/neovim/nvim-lspconfig/pull/4084) to the `lspconfig` repo adding it. Once some default configs for leanls are in `lsp/` this small change should work without the message that the deprecated framework is used. 
This is related to Issue #427