### PR TITLE
remove deprecated lspconfig call

### DIFF
--- a/lua/lean/lsp.lua
+++ b/lua/lean/lsp.lua
@@ -225,7 +225,7 @@ function lsp.enable(opts)
         or 'Goals accomplished 🎉'
     end,
   })
-  require('lspconfig').leanls.setup(opts)
+  vim.lsp.config("leanls", opts)
 end
 
 ---Restart the Lean server for an open Lean 4 file.


### PR DESCRIPTION
The `require('lspconfig').<server>.setup()` syntax is deprecated, and throws a warning whenever called. This PR simply moves it to the new syntax.