### PR TITLE
README.md: fix syntax error in example lazy.nvim plugin installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ It is undoubtedly the case that `lean.nvim` would not be as featureful without t
 Here's an example doing so with [lazy.nvim](https://github.com/folke/lazy.nvim):
 
 ```lua
-{
+return {
   'Julian/lean.nvim',
   event = { 'BufReadPre *.lean', 'BufNewFile *.lean' },
 


### PR DESCRIPTION
NVIM v0.11.4 (via neovim-snap on Ubuntu 24.04) and the latest lazy.nvim gives the error "unexpected symbol near '{'" without the return keyword.