### PR TITLE
Preserve stale goal state while processing

### DIFF
--- a/lua/lean/config.lua
+++ b/lua/lean/config.lua
@@ -46,6 +46,7 @@
 ---@class lean.infoview.Config
 ---@field mappings? { [string]: ElementEvent }
 ---@field orientation? "auto"|"vertical"|"horizontal" what orientation to use for opened infoviews
+---@field keep_stale_goal? boolean preserve the last goal state while Lean is processing instead of clearing it
 ---@field view_options? InfoviewViewOptions
 ---@field severity_markers? table<lsp.DiagnosticSeverity, string> characters to use for denoting diagnostic severity
 

--- a/lua/lean/infoview.lua
+++ b/lua/lean/infoview.lua
@@ -1140,7 +1140,7 @@ local function contents_for(params, use_widgets)
     elseif options.show_no_info_message then
       return components.NO_INFO
     else
-      return components.EMPTY
+      return Element.EMPTY
     end
   end
 
@@ -1201,6 +1201,8 @@ Pin.update = a.void(function(self)
   local new_element = contents_for(self.__position_params, self.__use_widgets)
   if new_element == nil then
     local has_stale = self.__data_element ~= Element.EMPTY
+      and self.__data_element ~= components.NO_INFO
+      and self.__data_element ~= components.PROCESSING
       and self.__data_element_uri == current_uri
     if has_stale then
       -- Preserve stale goal, indicate staleness visually.

--- a/lua/lean/infoview.lua
+++ b/lua/lean/infoview.lua
@@ -886,6 +886,7 @@ function Pin:new(obj)
     vim.tbl_extend('keep', obj, {
       paused = paused,
       __data_element = Element.EMPTY,
+      __data_element_uri = nil,
       __element = Element:new { name = 'pin' },
       __info = obj.parent,
       __tick = 0,
@@ -1196,17 +1197,21 @@ Pin.update = a.void(function(self)
     self.loading = true
     self.__info:render()
   end
+  local current_uri = self.__position_params.textDocument.uri
   local new_element = contents_for(self.__position_params, self.__use_widgets)
   if new_element == nil then
-    if self.__data_element == Element.EMPTY then
-      -- First open: nothing stale to preserve, show "Processing file...".
-      self.__data_element = components.PROCESSING
-      self.__element:set_children { self.__data_element }
-    else
-      -- Subsequent: preserve stale goal, indicate staleness visually.
+    local has_stale = self.__data_element ~= Element.EMPTY
+      and self.__data_element_uri == current_uri
+    if has_stale then
+      -- Preserve stale goal, indicate staleness visually.
       if self.__info.__infoview.window then
         self.__info.__infoview.window.o.winhighlight = 'NormalNC:leanInfoProcessing'
       end
+    else
+      -- No stale state for this file, show "Processing file...".
+      self.__data_element = components.PROCESSING
+      self.__data_element_uri = current_uri
+      self.__element:set_children { self.__data_element }
     end
     if self.__tick == tick and self.__info and self.loading then
       self.loading = false
@@ -1215,6 +1220,7 @@ Pin.update = a.void(function(self)
     return
   end
   self.__data_element = new_element
+  self.__data_element_uri = current_uri
   -- FIXME: we don't have the right separation here for knowing when we're dead
   if self.__data_element == components.LSP_HAS_DIED then
     self.__info.__infoview.window.o.winhighlight = 'NormalNC:leanInfoLSPDead'

--- a/lua/lean/infoview.lua
+++ b/lua/lean/infoview.lua
@@ -40,6 +40,7 @@ local options = {
   autopause = false,
   indicators = 'auto',
   show_processing = true,
+  keep_stale_goal = true,
   show_no_info_message = false,
   show_term_goals = true,
   use_widgets = true,
@@ -1084,10 +1085,13 @@ end
 ---
 ---@param params lsp.TextDocumentPositionParams
 ---@param use_widgets boolean
----@return Element
+---@return Element?
 local function contents_for(params, use_widgets)
   local processing = progress.at(params)
   if processing == progress.Kind.processing then
+    if options.keep_stale_goal then
+      return nil
+    end
     -- When Lean is processing, diagnostics indicate what's building,
     -- but those diagnostics show up at the top of the file.
     --
@@ -1192,7 +1196,25 @@ Pin.update = a.void(function(self)
     self.loading = true
     self.__info:render()
   end
-  self.__data_element = contents_for(self.__position_params, self.__use_widgets)
+  local new_element = contents_for(self.__position_params, self.__use_widgets)
+  if new_element == nil then
+    if self.__data_element == Element.EMPTY then
+      -- First open: nothing stale to preserve, show "Processing file...".
+      self.__data_element = components.PROCESSING
+      self.__element:set_children { self.__data_element }
+    else
+      -- Subsequent: preserve stale goal, indicate staleness visually.
+      if self.__info.__infoview.window then
+        self.__info.__infoview.window.o.winhighlight = 'NormalNC:leanInfoProcessing'
+      end
+    end
+    if self.__tick == tick and self.__info and self.loading then
+      self.loading = false
+      self.__info:render()
+    end
+    return
+  end
+  self.__data_element = new_element
   -- FIXME: we don't have the right separation here for knowing when we're dead
   if self.__data_element == components.LSP_HAS_DIED then
     self.__info.__infoview.window.o.winhighlight = 'NormalNC:leanInfoLSPDead'

--- a/lua/lean/infoview.lua
+++ b/lua/lean/infoview.lua
@@ -1207,15 +1207,19 @@ Pin.update = a.void(function(self)
       if self.__info.__infoview.window then
         self.__info.__infoview.window.o.winhighlight = 'NormalNC:leanInfoProcessing'
       end
+      if self.__tick == tick and self.__info and self.loading then
+        self.loading = false
+        self.__info:render()
+      end
     else
-      -- No stale state for this file, show "Processing file...".
+      -- No stale state for this file, show "Processing file..." but keep
+      -- loading so that wait_for_loading_pins continues to wait for real content.
       self.__data_element = components.PROCESSING
       self.__data_element_uri = current_uri
       self.__element:set_children { self.__data_element }
-    end
-    if self.__tick == tick and self.__info and self.loading then
-      self.loading = false
-      self.__info:render()
+      if self.__tick == tick and self.__info then
+        self.__info:render()
+      end
     end
     return
   end

--- a/lua/lean/stderr.lua
+++ b/lua/lean/stderr.lua
@@ -32,6 +32,7 @@ local function open_window(stderr_buffer)
 
   local stderr_window = Window:current()
   stderr_window:set_height(stderr_height)
+  stderr_window.o.winhighlight = 'NormalNC:Normal'
   stderr_buffer.o.filetype = 'leanstderr'
   initial_window:make_current()
   return stderr_window

--- a/spec/infoview/contents_spec.lua
+++ b/spec/infoview/contents_spec.lua
@@ -226,10 +226,6 @@ describe('interactive infoview', function()
           ⊢ 𝔽 = 𝔽
         ]]
 
-      helpers.move_cursor { to = { 1, 44 } }
-      assert.infoview_contents.are [[
-      ]]
-
       helpers.move_cursor { to = { 1, 46 } }
       assert.infoview_contents.are [[
         ▼ expected type (1:40-1:43)

--- a/spec/infoview/plain_contents_spec.lua
+++ b/spec/infoview/plain_contents_spec.lua
@@ -137,10 +137,6 @@ describe('plain infoviews', function()
           ⊢ 𝔽 = 𝔽
         ]]
 
-      helpers.move_cursor { to = { 1, 44 } }
-      assert.infoview_contents.are [[
-      ]]
-
       helpers.move_cursor { to = { 1, 46 } }
       assert.infoview_contents.are [[
         ▼ expected type (1:40-1:43)

--- a/spec/std/nvim/window_spec.lua
+++ b/spec/std/nvim/window_spec.lua
@@ -115,6 +115,7 @@ describe('Window', function()
         border = config.border,
         focusable = config.focusable,
         mouse = config.mouse,
+        style = config.style,
         zindex = config.zindex,
       }, config)
       float:close()

--- a/spec/widgets/core_spec.lua
+++ b/spec/widgets/core_spec.lua
@@ -76,6 +76,7 @@ describe('Lean core widgets', function()
         ]]
 
         infoview.go_to()
+        vim.api.nvim_win_set_cursor(0, { 1, 0 })
         helpers.search 'apply] '
         helpers.feed '<CR>'
 

--- a/syntax/leaninfo.lua
+++ b/syntax/leaninfo.lua
@@ -20,6 +20,7 @@ vim.api.nvim_set_hl(0, 'leanInfoExpectedType', { default = true, link = 'Special
 vim.api.nvim_set_hl(0, 'leanInfoNCWarn', { default = true, link = 'Folded' })
 vim.api.nvim_set_hl(0, 'leanInfoNCError', { default = true, link = 'NormalFloat' })
 vim.api.nvim_set_hl(0, 'leanInfoPaused', { default = true, link = 'leanInfoNCWarn' })
+vim.api.nvim_set_hl(0, 'leanInfoProcessing', { default = true, link = 'leanInfoNCWarn' })
 vim.api.nvim_set_hl(0, 'leanInfoLSPDead', { default = true, link = 'leanInfoNCError' })
 
 -- Diagnostics


### PR DESCRIPTION
## Summary
When Lean is processing a file, the infoview now preserves the last rendered goal state instead of clearing it and showing only "Processing file...". This lets you reference existing hypotheses while writing proofs without waiting for recompilation.

- Adds `keep_stale_goal` option (default: `true`) to infoview config
- When enabled and Lean is processing, the previous goal state is kept visible
- The infoview window gets a `leanInfoProcessing` winhighlight (`NormalNC`) to visually indicate the displayed state is stale
- The stderr window is explicitly excluded from the processing tint via `NormalNC:Normal` override
- On first file open (no previous state), falls back to showing "Processing file..." as before
- Only preserves stale state when cursor is inside a declaration — moving to a comment between theorems correctly clears the infoview (upstream `contents_for` returned `nil` via nonexistent `components.EMPTY` for no-info positions, which our stale logic mistook for "processing")
- Fixes a pre-existing flaky test in `core_spec.lua` where the infoview cursor position persisted between tests causing `helpers.search` to fail
- Fixes a nightly-only test failure in `window_spec.lua` where neovim added a `style` field to `nvim_win_get_config()` output

### Demo
https://github.com/user-attachments/assets/e9e96fd8-746a-4442-9eea-38b07d3e960d

## Related issues
- Closes #369 — Still show last compiled goal-state while `Processing file...`
- Addresses #257 — Make how and when the infoview updates more configurable

## Try Yourself
if you wanna try yourself before merging, - here is the list of expected behavior and possible pitfalls.
- Open a Lean file, verify "Processing file..." shows on first load
- Edit a proof, verify the previous goal state persists while processing
- Verify the infoview background tints when showing stale state (unfocused)
- Verify the stderr window does not get tinted
- Move cursor to a comment between declarations, verify stale goal clears
- Set `keep_stale_goal = false` and verify original behavior is preserved
- Check switching to a different file does not show old one's goalstate while loading