### PR TITLE
Highlight ≠ and ^ as operators

### DIFF
--- a/demos/basic.lua
+++ b/demos/basic.lua
@@ -100,7 +100,7 @@ end
 function DEMO.wait_for_infoview(opts)
   opts = opts or {}
   local timeout = opts.timeout or 30000
-  local infoview = require('lean.infoview')
+  local infoview = require 'lean.infoview'
   vim.wait(timeout, function()
     local iv = infoview.get_current_infoview()
     if not iv then

--- a/syntax/lean.vim
+++ b/syntax/lean.vim
@@ -57,7 +57,7 @@ syn match leanCommandPrefix '@' nextgroup=leanAttributeArgs
 syn keyword leanCommandPrefix attribute skipwhite nextgroup=leanAttributeArgs
 
 " constants
-syn match leanOp "[:=><λ←→↔∀∃∧∨¬≤≥▸·+*-/;$|&%!×]"
+syn match leanOp "[:=≠><λ←→↔∀∃∧∨¬≤≥▸·+*-/^;$|&%!×]"
 syn match leanOp '\([A-Za-z]\)\@<!?'
 
 " delimiters


### PR DESCRIPTION
Thanks for the plugin !
The usual operators `+*-/` are highlighted as `leanOp` in `syntax/lean.vim`, but not `^` (exponentiation), and `=<>` are also highlighted as `leanOp` but not `≠`, so I suggest adding these.