### PR TITLE
Use line comment for 'commentstring'

### DIFF
--- a/ftplugin/lean/lean.lua
+++ b/ftplugin/lean/lean.lua
@@ -7,7 +7,7 @@ vim.opt.wildignore:append [[*.olean]]
 
 vim.bo.iskeyword = [[a-z,A-Z,_,48-57,192-255,!,',?,#]]
 vim.bo.comments = [[s0:/-,mb: ,ex:-/,:--]]
-vim.bo.commentstring = [[/- %s -/]]
+vim.bo.commentstring = [[-- %s]]
 
 vim.bo.includeexpr = [[substitute(v:fname, '\.', '/', 'g') . '.lean']]
 


### PR DESCRIPTION
`'commentstring'` is used by Neovim in a way that line comments seem more fitting.

Additionally, there is a quirk/bug of Neovim that interacts badly with Lean's comment syntax and can cause unterminated comments to show up.

To reproduce, perform a visual selection accross paragraphs, including an empty line. Then comment it out using `gcc`. The empty line will be left with `/--/`, which in Lean is the *start* of a doc comment, without a corresponding end of the comment, so the remainder of the file gets read as a comment. The quirk is that the spaces around `%s` seem to be ignored for empty lines.