### PR TITLE
optional abbreviations on hover

### DIFF
--- a/lua/lean/config.lua
+++ b/lua/lean/config.lua
@@ -36,6 +36,7 @@
 ---@field enable? boolean whether to automatically enable expansion
 ---@field leader? string which key to use to trigger abbreviation expansion
 ---@field extra table<string, string> a table of extra abbreviations to enable
+---@field show_in_hover? boolean whether to show matching abbreviations in enhanced hovers
 
 ---@class lean.ft.Config
 ---@field nomodifiable string[] globs to prevent accidental modification
@@ -179,6 +180,7 @@ local DEFAULTS = {
   abbreviations = {
     leader = '\\',
     extra = {},
+    show_in_hover = false,
   },
 
   ---@type lean.ft.MergedConfig

--- a/lua/lean/hover.lua
+++ b/lua/lean/hover.lua
@@ -13,6 +13,7 @@ local Buffer = require 'std.nvim.buffer'
 local async = require 'std.async'
 
 local Element = require('lean.tui').Element
+local abbreviations = require 'lean.abbreviations'
 local InteractiveCode = require 'lean.widget.interactive_code'
 local lsp = require 'lean.lsp'
 local rpc = require 'lean.rpc'
@@ -134,6 +135,21 @@ end
 -- https://github.com/leanprover/vscode-lean4/blob/dd686d7/lean4-infoview/src/infoview/interactiveCode.tsx#L112
 return function()
   local params = vim.lsp.util.make_position_params(0, 'utf-16')
+  local abbreviation_hint
+  if require 'lean.config'().abbreviations.show_in_hover then
+    local col = vim.api.nvim_win_get_cursor(0)[2] + 1
+    local char = vim.api.nvim_get_current_line():sub(col)
+    local reverse = abbreviations.reverse_lookup(char)
+    local matches = {}
+    for length = 1, #char do
+      if reverse[length] ~= nil then
+        vim.list_extend(matches, reverse[length])
+      end
+    end
+    if #matches > 0 then
+      abbreviation_hint = 'Abbreviations: ' .. table.concat(matches, ', ')
+    end
+  end
 
   async.run(function()
     local sess = rpc.open(params)
@@ -166,7 +182,11 @@ return function()
     end
     lean_code:add_child(InteractiveCode(term_goal.type, sess))
 
-    local children = { lean_code }
+    local children = {}
+    if abbreviation_hint then
+      table.insert(children, Element:new { text = abbreviation_hint .. '\n' })
+    end
+    table.insert(children, lean_code)
     if doc then
       table.insert(children, Element:new { text = '\n\n' .. doc })
     end

--- a/lua/lean/hover.lua
+++ b/lua/lean/hover.lua
@@ -13,8 +13,8 @@ local Buffer = require 'std.nvim.buffer'
 local async = require 'std.async'
 
 local Element = require('lean.tui').Element
-local abbreviations = require 'lean.abbreviations'
 local InteractiveCode = require 'lean.widget.interactive_code'
+local abbreviations = require 'lean.abbreviations'
 local lsp = require 'lean.lsp'
 local rpc = require 'lean.rpc'
 


### PR DESCRIPTION
Adds support for optional abbreviations on LeanHover command, doesn't add anything if there are no abbreviations for a symbol

<img width="1038" height="309" alt="image" src="https://github.com/user-attachments/assets/cb0036b8-46d7-41de-891a-cd7b3d1d800e" />
