### PR TITLE
Preserve noremap when restoring abbreviation mappings

### DIFF
--- a/lua/lean/abbreviations.lua
+++ b/lua/lean/abbreviations.lua
@@ -169,6 +169,7 @@ local function insert_char_pre()
       if mappings[lhs] then
         cleanups[lhs] = function()
           vim.api.nvim_buf_set_keymap(buf.bufnr, 'i', lhs, rhs, {
+            noremap = imap.noremap,
             nowait = imap.nowait,
             silent = imap.silent,
             script = imap.script,

--- a/spec/abbreviations/abbreviations_spec.lua
+++ b/spec/abbreviations/abbreviations_spec.lua
@@ -115,6 +115,7 @@ describe('unicode abbreviation expansion', function()
         wait_for_expansion()
         assert.contents.are [[ε]]
         assert.are.same(vim.b.foo, 1)
+        assert.is.equal(1, vim.fn.maparg('<Tab>', 'i', false, true).noremap)
         helpers.insert [[<Tab>]]
         assert.contents.are [[ε]]
         assert.are.same(vim.b.foo, 2)


### PR DESCRIPTION
## Summary

- preserve `noremap` when restoring insert-mode mappings after Unicode abbreviation input
- assert that an existing non-recursive Lua mapping remains non-recursive

## Why

Unicode abbreviation handling temporarily replaces `<CR>` and `<Tab>`, then recreates the previous mappings. The recreation preserved several mapping attributes, including `desc`, but dropped `noremap`.

That can turn a non-recursive completion fallback mapping into a recursive one. With blink.cmp and nvim-autopairs, pressing Enter after entering a Lean abbreviation can then re-enter the same fallback mapping until Neovim overflows its stack or hangs.

This completes the mapping restoration addressed in #367 and fixes a recurrence of the symptom reported in saghen/blink.cmp#441.

## Validation

- `just retest spec/abbreviations/abbreviations_spec.lua` with unwrapped Neovim: 14 passed
- StyLua check passed
- Luacheck: 0 warnings / 0 errors
- Selene: 0 errors
- manual reproduction on Neovim 0.12.2 with blink.cmp 1.10.2 and nvim-autopairs 0.10.0: `\or ` → `∨`, type `(`, then press Enter inside `()`; the mapping is restored with `noremap=1` and Enter inserts a newline normally
