### PR TITLE
Allow clicking outside infoview to switch focus

### DIFF
--- a/lua/lean/tui.lua
+++ b/lua/lean/tui.lua
@@ -952,7 +952,7 @@ function BufRenderer:new(obj)
   local function dispatch_mouse(event)
     local pos = vim.fn.getmousepos()
     if pos.winid == 0 or pos.line == 0 or vim.api.nvim_win_get_buf(pos.winid) ~= buf.bufnr then
-      vim.api.nvim_feedkeys(vim.keycode("<LeftMouse>"), "nx", false)
+      vim.api.nvim_feedkeys(vim.keycode '<LeftMouse>', 'nx', false)
       return
     end
     local line_len = #buf:line(pos.line - 1)

--- a/lua/lean/tui.lua
+++ b/lua/lean/tui.lua
@@ -951,10 +951,8 @@ function BufRenderer:new(obj)
   -- selection.
   local function dispatch_mouse(event)
     local pos = vim.fn.getmousepos()
-    if pos.winid == 0 or pos.line == 0 then
-      return
-    end
-    if vim.api.nvim_win_get_buf(pos.winid) ~= buf.bufnr then
+    if pos.winid == 0 or pos.line == 0 or vim.api.nvim_win_get_buf(pos.winid) ~= buf.bufnr then
+      vim.api.nvim_feedkeys(vim.keycode("<LeftMouse>"), "nx", false)
       return
     end
     local line_len = #buf:line(pos.line - 1)


### PR DESCRIPTION
As in the title.

I face the following issue: When the cursor is currently in the infoview window, and I click on another window, it will just be stuck there instead of switching focus to another window (which is the expected behavior).

This pull request fixes that.

The newly added line can be changed to

```
vim.cmd([[exec "normal! \<LeftMouse>"]])
```

which is shorter, but seems less elegant since you need to invoke the Vim interpreter instead of staying entirely inside Lua.